### PR TITLE
Improve performance

### DIFF
--- a/src/bytecode/instructions.rs
+++ b/src/bytecode/instructions.rs
@@ -1,6 +1,5 @@
-use std::cmp::{Ord, Ordering, PartialOrd};
+use std::cmp::{Ordering, PartialOrd};
 use std::fmt::{Display, Formatter, Result};
-use bytecode::LuaBytecode;
 
 /// This enum represents all possible Lua values.
 #[derive(Clone, Debug)]
@@ -37,69 +36,10 @@ impl Display for Value {
     }
 }
 
-#[derive(Clone)]
-pub struct Reg {
-    id: usize,
-    value: Value
-}
-
-impl Reg {
-    pub fn new(id: usize) -> Reg {
-        Reg { id, value: Value::Nil }
-    }
-
-    pub fn id(&self) -> usize {
-        self.id
-    }
-
-    pub fn get_value(&self) -> &Value {
-        &self.value
-    }
-
-    pub fn set_value(&mut self, value: Value) {
-        self.value = value;
-    }
-}
-
-impl Display for Reg {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(f, "{} = {}", self.id, self.value)
-    }
-}
-
-impl PartialEq for Reg {
-    fn eq(&self, other: &Reg) -> bool {
-        self.id == other.id
-    }
-}
-
-impl Eq for Reg {}
-
-impl PartialOrd for Reg {
-    fn partial_cmp(&self, other: &Reg) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Reg {
-    fn cmp(&self, other: &Reg) -> Ordering {
-        self.id.cmp(&other.id)
-    }
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Val {
     LuaValue(Value),
     Register(usize)
-}
-
-impl Val {
-    pub fn get_value<'a>(&'a self, bytecode: &'a LuaBytecode) -> &'a Value {
-        match *self {
-            Val::LuaValue(ref value) => &value,
-            Val::Register(reg) => bytecode.get_value(reg)
-        }
-    }
 }
 
 impl Display for Val {

--- a/src/bytecode/mod.rs
+++ b/src/bytecode/mod.rs
@@ -2,19 +2,19 @@ pub mod instructions;
 
 use std::vec::Vec;
 use std::fmt;
-use self::instructions::{Reg, Instr, Value};
+use self::instructions::{Instr};
 
 /// A simpler representation of Lua
 pub struct LuaBytecode {
     block: Vec<Instr>,
-    registers: Vec<Reg>
+    reg_count: usize
 }
 
 impl LuaBytecode {
-    pub fn new(instrs: Vec<Instr>, registers: Vec<Reg>) -> LuaBytecode {
+    pub fn new(instrs: Vec<Instr>, reg_count: usize) -> LuaBytecode {
         LuaBytecode {
             block: instrs,
-            registers,
+            reg_count,
         }
     }
 
@@ -25,17 +25,14 @@ impl LuaBytecode {
 
     /// Get the list of instructions that can be executed in order
     /// to perform some computation.
-    pub fn get_instr(&self, index: usize) -> Instr {
-        self.block[index].clone()
+    pub fn get_instr(&self, index: usize) -> &Instr {
+        &self.block[index]
     }
 
-    /// Set the register to the given value
-    pub fn set_value(&mut self, id: usize, value: Value) {
-        self.registers[id].set_value(value);
-    }
-
-    pub fn get_value(&self, id: usize) -> &Value {
-        self.registers[id].get_value()
+    /// Get the number of registers that this bytecode uses in order to encode
+    /// instructions.
+    pub fn reg_count(&self) -> usize {
+        self.reg_count
     }
 }
 
@@ -53,25 +50,17 @@ impl fmt::Display for LuaBytecode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use super::instructions::*;
 
     #[test]
     fn bytecode_works_correctly() {
         let instrs = vec![
-            Instr::Mov(0, instructions::Val::LuaValue(Value::Nil))
+            Instr::Mov(0, Val::LuaValue(Value::Nil))
         ];
-        let registers = vec![
-            Reg::new(0),
-            Reg::new(1)
-        ];
-        let mut bc = LuaBytecode::new(instrs, registers);
-        // check if register values are correctly updated
-        assert_eq!(*bc.get_value(0), Value::Nil);
-        assert_eq!(*bc.get_value(1), Value::Nil);
-        bc.set_value(0, Value::Boolean(false));
-        assert_eq!(*bc.get_value(0), Value::Boolean(false));
-
+        let mut bc = LuaBytecode::new(instrs, 3);
+        assert_eq!(bc.reg_count(), 3);
         assert_eq!(bc.instrs_len(), 1);
-        assert_eq!(bc.get_instr(0),
+        assert_eq!(*bc.get_instr(0),
                    Instr::Mov(0, instructions::Val::LuaValue(Value::Nil)));
     }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,17 +1,26 @@
+mod register;
+
 use bytecode::LuaBytecode;
 use bytecode::instructions::Value;
 use bytecode::instructions::Val;
 use bytecode::instructions::Instr::*;
+use self::register::Reg;
 
 /// Represents a `LuaBytecode` interpreter.
 pub struct Interpreter {
-    bytecode: LuaBytecode
+    bytecode: LuaBytecode,
+    registers: Vec<Reg>
 }
 
 impl Interpreter {
     /// Create a new interpreter for the given bytecode.
     pub fn new(bytecode: LuaBytecode) -> Interpreter {
-        Interpreter{ bytecode }
+        let regs = bytecode.reg_count();
+        let mut registers = Vec::with_capacity(regs);
+        for _ in 0..regs {
+            registers.push(Reg::new());
+        }
+        Interpreter{ bytecode, registers }
     }
 
     /// Evaluate the program.
@@ -20,31 +29,31 @@ impl Interpreter {
         let len = self.bytecode.instrs_len();
         while pc < len {
             let instr = self.bytecode.get_instr(pc);
-            match instr {
+            match *instr {
                 Mov(reg, ref value) => {
-                    let val = value.get_value(&self.bytecode).clone();
-                    self.bytecode.set_value(reg, val);
+                    let val = self.get_value(value).clone();
+                    self.registers[reg].set_value(val);
                 },
                 Add(reg, ref lhs, ref rhs) => {
                     let res = self.eval_arithmetic_op(&lhs, &rhs, lua_add);
-                    self.bytecode.set_value(reg, res);
+                    self.registers[reg].set_value(res);
                 },
                 Sub(reg, ref lhs, ref rhs) => {
                     let res = self.eval_arithmetic_op(&lhs, &rhs, lua_sub);
-                    self.bytecode.set_value(reg, res);
+                    self.registers[reg].set_value(res);
                 },
                 Mul(reg, ref lhs, ref rhs) => {
                     let res = self.eval_arithmetic_op(&lhs, &rhs, lua_mul);
-                    self.bytecode.set_value(reg, res);
+                    self.registers[reg].set_value(res);
                 },
                 Div(reg, ref lhs, ref rhs) => {
                     let res = self.eval_arithmetic_op(&lhs, &rhs, lua_div);
-                    self.bytecode.set_value(reg, res);
+                    self.registers[reg].set_value(res);
                 },
                 Mod(reg, ref lhs, ref rhs) => {
                     let res = self.eval_arithmetic_op(&lhs, &rhs, lua_mod);
-                    self.bytecode.set_value(reg, res);
-                },
+                    self.registers[reg].set_value(res);
+                }
             }
             pc += 1;
         }
@@ -53,12 +62,19 @@ impl Interpreter {
     /// Apply <op> to the given `Value`s.
     fn eval_arithmetic_op(&self, lhs: &Val, rhs: &Val,
                           op: fn(f64, f64) -> Value) -> Value {
-        let lhs = lhs.get_value(&self.bytecode);
-        let rhs = rhs.get_value(&self.bytecode);
+        let lhs = self.get_value(lhs);
+        let rhs = self.get_value(rhs);
         match (lhs, rhs) {
             (Value::Number(l), Value::Number(r)) => op(*l, *r),
             (_, _) =>
                 panic!("Unable to perform arithmetic on {} and {}", lhs, rhs)
+        }
+    }
+
+    fn get_value<'a>(&'a self, val: &'a Val) -> &'a Value {
+        match val {
+            Val::LuaValue(ref value) => &value,
+            Val::Register(reg) => self.registers[*reg].get_value()
         }
     }
 }
@@ -73,28 +89,27 @@ fn lua_mod(lhs: f64, rhs: f64) -> Value { Value::Number(lhs % rhs) }
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytecode::instructions::Reg;
 
     #[test]
     fn interpreter_works_correctly() {
         let mut regs = vec![];
         for i in 0..6 {
-            regs.push(Reg::new(i));
+            regs.push(i);
         }
         let instrs = vec![
-            Mov(regs[0].id(), Val::LuaValue(Value::Number(0.0))),
-            Add(regs[1].id(), Val::LuaValue(Value::Number(1.0)),
+            Mov(regs[0], Val::LuaValue(Value::Number(0.0))),
+            Add(regs[1], Val::LuaValue(Value::Number(1.0)),
                 Val::LuaValue(Value::Number(1.0))),
-            Sub(regs[2].id(), Val::LuaValue(Value::Number(1.0)),
+            Sub(regs[2], Val::LuaValue(Value::Number(1.0)),
                 Val::LuaValue(Value::Number(1.0))),
-            Mul(regs[3].id(), Val::LuaValue(Value::Number(1.0)),
+            Mul(regs[3], Val::LuaValue(Value::Number(1.0)),
                 Val::LuaValue(Value::Number(2.0))),
-            Div(regs[4].id(), Val::LuaValue(Value::Number(2.0)),
+            Div(regs[4], Val::LuaValue(Value::Number(2.0)),
                 Val::LuaValue(Value::Number(2.0))),
-            Mod(regs[5].id(), Val::LuaValue(Value::Number(3.0)),
+            Mod(regs[5], Val::LuaValue(Value::Number(3.0)),
                 Val::LuaValue(Value::Number(2.0))),
         ];
-        let bytecode = LuaBytecode::new(instrs, regs.clone());
+        let bytecode = LuaBytecode::new(instrs, regs.len());
         let expected = vec![
             Value::Number(0.0),
             Value::Number(2.0),
@@ -106,8 +121,8 @@ mod tests {
 
         let mut interpreter = Interpreter::new(bytecode);
         interpreter.eval();
-        for (i, ref r) in regs.iter().enumerate() {
-            assert_eq!(*interpreter.bytecode.get_value(r.id()), expected[i]);
+        for (i, r) in regs.iter().enumerate() {
+            assert_eq!(*interpreter.registers[*r].get_value(), expected[i]);
         }
     }
 }

--- a/src/interpreter/register.rs
+++ b/src/interpreter/register.rs
@@ -1,0 +1,20 @@
+use bytecode::instructions::Value;
+
+#[derive(Clone, Debug)]
+pub struct Reg {
+    value: Value
+}
+
+impl Reg {
+    pub fn new() -> Reg {
+        Reg { value: Value::Nil }
+    }
+
+    pub fn get_value(&self) -> &Value {
+        &self.value
+    }
+
+    pub fn set_value(&mut self, value: Value) {
+        self.value = value;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ impl LuaParseTree {
                 _ => { continue; }
             }
         }
-        LuaBytecode::new(instrs, reg_map.get_registers())
+        LuaBytecode::new(instrs, reg_map.reg_count())
     }
 
     /// Jumps to the first child of <node> which denotes a variable name.
@@ -103,7 +103,7 @@ impl LuaParseTree {
                     let left = self.compile_expr(&nodes[0], instrs, reg_map);
                     let right = self.compile_expr(&nodes[2], instrs, reg_map);
                     let new_var = reg_map.new_reg();
-                    instrs.push(self.get_instr(&nodes[1], Reg::new(new_var), left, right));
+                    instrs.push(self.get_instr(&nodes[1], new_var, left, right));
                     Register(new_var)
                 }
             },
@@ -120,14 +120,14 @@ impl LuaParseTree {
     }
 
     /// Get the appropriate instruction for a given Node::Term.
-    fn get_instr(&self, node: &Node<u8>, reg: Reg, lhs: Val, rhs: Val) -> Instr {
+    fn get_instr(&self, node: &Node<u8>, reg: usize, lhs: Val, rhs: Val) -> Instr {
         if let Term{lexeme} = node {
             match lexeme.tok_id() {
-                lua5_3_l::T_PLUS => Instr::Add(reg.id(), lhs, rhs),
-                lua5_3_l::T_MINUS => Instr::Sub(reg.id(), lhs, rhs),
-                lua5_3_l::T_STAR => Instr::Mul(reg.id(), lhs, rhs),
-                lua5_3_l::T_FSLASH => Instr::Div(reg.id(), lhs, rhs),
-                lua5_3_l::T_MOD => Instr::Mod(reg.id(), lhs, rhs),
+                lua5_3_l::T_PLUS => Instr::Add(reg, lhs, rhs),
+                lua5_3_l::T_MINUS => Instr::Sub(reg, lhs, rhs),
+                lua5_3_l::T_STAR => Instr::Mul(reg, lhs, rhs),
+                lua5_3_l::T_FSLASH => Instr::Div(reg, lhs, rhs),
+                lua5_3_l::T_MOD => Instr::Mod(reg, lhs, rhs),
                 _ => unimplemented!("Instruction {}", lexeme.tok_id())
             }
         } else {

--- a/src/register_map.rs
+++ b/src/register_map.rs
@@ -1,17 +1,17 @@
-use std::vec::Vec;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use bytecode::instructions::Reg;
 
+/// Represents a structure that is used to keep track of the mapping
+/// between Lua variables and register ids.
 pub struct RegisterMap {
-    registers: RefCell<Vec<Reg>>,
+    reg_count: RefCell<usize>,
     reg_map: RefCell<HashMap<String, usize>>
 }
 
 impl RegisterMap {
     pub fn new() -> RegisterMap {
         RegisterMap {
-            registers: RefCell::new(vec![]),
+            reg_count: RefCell::new(0),
             reg_map: RefCell::new(HashMap::new())
         }
     }
@@ -20,9 +20,9 @@ impl RegisterMap {
     /// This is used in cases like `x = 1 + 2 + 3` to generate intermmediate
     /// registers in which, for instance, the result of 2 + 3 is stored.
     pub fn new_reg(&self) -> usize {
-        let len = self.registers.borrow().len();
-        self.registers.borrow_mut().push(Reg::new(len));
-        len + 1
+        let to_return = *self.reg_count.borrow();
+        *self.reg_count.borrow_mut() += 1;
+        to_return
     }
 
     /// Get the register that corresponds to the given identifier.
@@ -32,7 +32,8 @@ impl RegisterMap {
         *self.reg_map.borrow_mut().entry(name.to_string()).or_insert(self.new_reg())
     }
 
-    pub fn get_registers(self) -> Vec<Reg> {
-        self.registers.borrow_mut().to_vec()
+    /// Get the total number of registers that were needed.
+    pub fn reg_count(self) -> usize {
+        *self.reg_count.borrow_mut()
     }
 }


### PR DESCRIPTION
One of the main changes is that the bytecode is now immutable. It is not
possible to add or remove instructions from it.

Another change in the structure of the bytecode is that it does not keep
track of registers any more. The original decision didn't make much sense, so
now the bytecode only records the number of registers that are used by
the instructions (represented by `reg_count`).

The interpreter now keeps track of all registers, and their values.

These changes are important because the interpreter can now get references to
bytecode instructions, while before the instructions were always copied. The
performance is also improved by the fact that the calls to
`bytecode.set/get_value` have been removed. All register manipulation is done
inside the interpreter.