### PR TITLE
Implement most arithmetic operators

### DIFF
--- a/src/bytecode/instructions.rs
+++ b/src/bytecode/instructions.rs
@@ -6,7 +6,8 @@ use std::fmt::{Display, Formatter, Result};
 pub enum Value {
     Nil,
     Boolean(bool),
-    Number(f64),
+    Integer(i64),
+    Float(f64),
     Str(String),
 }
 
@@ -15,7 +16,8 @@ impl PartialEq for Value {
         match (self, other) {
             (Value::Nil, Value::Nil) => true,
             (Value::Boolean(l), Value::Boolean(r)) => l == r,
-            (Value::Number(l), Value::Number(r)) =>
+            (Value::Integer(l), Value::Integer(r)) => l == r,
+            (Value::Float(l), Value::Float(r)) =>
                 l.partial_cmp(r).unwrap() == Ordering::Equal,
             (Value::Str(l), Value::Str(r)) => l == r,
             (_, _) => false
@@ -30,7 +32,8 @@ impl Display for Value {
         match *self {
             Value::Nil => write!(f, "Nil"),
             Value::Boolean(b) => write!(f, "{}", b.to_string()),
-            Value::Number(float) => write!(f, "{}", float),
+            Value::Integer(int) => write!(f, "{}", int),
+            Value::Float(float) => write!(f, "{}", float),
             Value::Str(ref content) => write!(f, "\"{}\"", content),
         }
     }
@@ -59,7 +62,8 @@ pub enum Instr {
     Sub(usize, Val, Val),
     Mul(usize, Val, Val),
     Div(usize, Val, Val),
-    Mod(usize, Val, Val)
+    Mod(usize, Val, Val),
+    FDiv(usize, Val, Val)
 }
 
 impl Display for Instr {
@@ -76,6 +80,8 @@ impl Display for Instr {
                 write!(f, "(div ${} {} {})", reg, lhs, rhs),
             Instr::Mod(reg, ref lhs, ref rhs) =>
                 write!(f, "(mod ${} {} {})", reg, lhs, rhs),
+            Instr::FDiv(reg, ref lhs, ref rhs) =>
+                write!(f, "(mod ${} {} {})", reg, lhs, rhs)
         }
     }
 }

--- a/src/bytecode/instructions.rs
+++ b/src/bytecode/instructions.rs
@@ -11,6 +11,38 @@ pub enum Value {
     Str(String),
 }
 
+impl Value {
+    /// Check whether the Value can be converted into a Float.
+    pub fn is_float(&self) -> bool {
+        match self {
+            Value::Float(_) | Value::Str(_) => true,
+            _ => false
+        }
+    }
+
+    /// Convert the Value to an f64. This conversion returns Some when the value is
+    /// either an Integer, a Float or a Str.
+    /// In Lua, string are always converted to floats when they are used in
+    /// arithmetic expressions.
+    pub fn to_float(&self) -> Option<f64> {
+        match self {
+            Value::Integer(value) => Some(*value as f64),
+            Value::Float(value) => Some(*value),
+            Value::Str(value) => value.parse().ok(),
+            _ => None
+        }
+    }
+
+    /// Convert the Value to an i64. This conversion returns Some when the value is
+    /// an Integer.
+    pub fn to_int(&self) -> Option<i64> {
+        match self {
+            Value::Integer(value) => Some(*value),
+            _ => None
+        }
+    }
+}
+
 impl PartialEq for Value {
     fn eq(&self, other: &Value) -> bool {
         match (self, other) {
@@ -63,7 +95,8 @@ pub enum Instr {
     Mul(usize, Val, Val),
     Div(usize, Val, Val),
     Mod(usize, Val, Val),
-    FDiv(usize, Val, Val)
+    FDiv(usize, Val, Val),
+    Exp(usize, Val, Val)
 }
 
 impl Display for Instr {
@@ -81,7 +114,9 @@ impl Display for Instr {
             Instr::Mod(reg, ref lhs, ref rhs) =>
                 write!(f, "(mod ${} {} {})", reg, lhs, rhs),
             Instr::FDiv(reg, ref lhs, ref rhs) =>
-                write!(f, "(mod ${} {} {})", reg, lhs, rhs)
+                write!(f, "(fdiv ${} {} {})", reg, lhs, rhs),
+            Instr::Exp(reg, ref lhs, ref rhs) =>
+                write!(f, "(exp ${} {} {})", reg, lhs, rhs)
         }
     }
 }

--- a/src/interpreter/arithmetic_operators.rs
+++ b/src/interpreter/arithmetic_operators.rs
@@ -1,0 +1,151 @@
+use bytecode::instructions::Value;
+use bytecode::instructions::Value::*;
+
+/// Converts the given values using the following rules:
+/// 1. if one of the arguments is a float, then convert both args to Float.
+/// 2. if one of the arguments is a string, then convert both args to Float.
+/// 3. if both arguments are integers, then simply return two Integer values.
+/// # Panics
+/// This panics when one of the arguments is a Bool or a Nil.
+fn to_int_or_float(lhs: &Value, rhs: &Value) -> (Value, Value) {
+    match (lhs, rhs) {
+        (Float(l), Float(r)) => (Float(*l), Float(*r)),
+        (Float(l), Integer(r)) => (Float(*l), Float(*r as f64)),
+        (Float(l), Str(r)) => (Float(*l), Float(r.parse().unwrap())),
+        (Integer(l), Float(r)) => (Float(*l as f64), Float(*r)),
+        (Integer(l), Integer(r)) => (Integer(*l), Integer(*r)),
+        (Integer(l), Str(r)) => (Float(*l as f64), Float(r.parse().unwrap())),
+        (Str(l), Float(r)) => (Float(l.parse().unwrap()), Float(*r)),
+        (Str(l), Integer(r)) => (Float(l.parse().unwrap()), Float(*r as f64)),
+        (Str(l), Str(r)) => (Float(l.parse().unwrap()), Float(r.parse().unwrap())),
+        (_, _ ) => panic!("Cannot convert to float or int {}, {}", lhs, rhs)
+    }
+}
+
+pub fn add(lhs: &Value, rhs: &Value) -> Value {
+    match to_int_or_float(lhs, rhs) {
+        (Float(l), Float(r)) => Float(l + r),
+        (Integer(l), Integer(r)) => Integer(l + r),
+        (_, _) => unreachable!()
+    }
+}
+
+pub fn sub(lhs: &Value, rhs: &Value) -> Value {
+    match to_int_or_float(lhs, rhs) {
+        (Float(l), Float(r)) => Float(l - r),
+        (Integer(l), Integer(r)) => Integer(l - r),
+        (_, _) => unreachable!()
+    }
+}
+
+pub fn mul(lhs: &Value, rhs: &Value) -> Value {
+    match to_int_or_float(lhs, rhs) {
+        (Float(l), Float(r)) => Float(l * r),
+        (Integer(l), Integer(r)) => Integer(l * r),
+        (_, _) => unreachable!()
+    }
+}
+
+pub fn div(lhs: &Value, rhs: &Value) -> Value {
+    match to_int_or_float(lhs, rhs) {
+        (Float(l), Float(r)) => Float(l / r),
+        (Integer(l), Integer(r)) => Integer(l / r),
+        (_, _) => unreachable!()
+    }
+}
+
+pub fn modulus(lhs: &Value, rhs: &Value) -> Value {
+    match to_int_or_float(lhs, rhs) {
+        (Float(l), Float(r)) => Float(l % r),
+        (Integer(l), Integer(r)) => Integer(l % r),
+        (_, _) => unreachable!()
+    }
+}
+
+pub fn fdiv(lhs: &Value, rhs: &Value) -> Value {
+    match to_int_or_float(lhs, rhs) {
+        (Float(l), Float(r)) => Float((l / r).floor()),
+        (Integer(l), Integer(r)) => Integer(l / r),
+        (_, _) => unreachable!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_operation(expected: Vec<Value>, op: fn(&Value, &Value) -> Value) {
+        let test_cases = vec![
+            op(&Integer(2), &Integer(2)),
+            op(&Integer(2), &Float(2.0)),
+            op(&Integer(2), &Str(String::from("2"))),
+            op(&Float(2.0), &Integer(2)),
+            op(&Float(2.0), &Float(2.0)),
+            op(&Float(2.0), &Str(String::from("2"))),
+            op(&Str(String::from("2")), &Integer(2)),
+            op(&Str(String::from("2")), &Float(2.0)),
+            op(&Str(String::from("2")), &Str(String::from("2")))
+        ];
+        assert_eq!(test_cases, expected);
+    }
+
+    #[test]
+    fn test_add() {
+        let expected = vec![
+            Integer(4), Float(4.0), Float(4.0),
+            Float(4.0), Float(4.0), Float(4.0),
+            Float(4.0), Float(4.0), Float(4.0),
+        ];
+        test_operation(expected, add);
+    }
+
+    #[test]
+    fn test_sub() {
+        let expected = vec![
+            Integer(0), Float(0.0), Float(0.0),
+            Float(0.0), Float(0.0), Float(0.0),
+            Float(0.0), Float(0.0), Float(0.0),
+        ];
+        test_operation(expected, sub);
+    }
+
+    #[test]
+    fn test_mul() {
+        let expected = vec![
+            Integer(4), Float(4.0), Float(4.0),
+            Float(4.0), Float(4.0), Float(4.0),
+            Float(4.0), Float(4.0), Float(4.0),
+        ];
+        test_operation(expected, mul);
+    }
+
+    #[test]
+    fn test_div() {
+        let expected = vec![
+            Integer(1), Float(1.0), Float(1.0),
+            Float(1.0), Float(1.0), Float(1.0),
+            Float(1.0), Float(1.0), Float(1.0),
+        ];
+        test_operation(expected, div);
+    }
+
+    #[test]
+    fn test_modulus() {
+        let expected = vec![
+            Integer(0), Float(0.0), Float(0.0),
+            Float(0.0), Float(0.0), Float(0.0),
+            Float(0.0), Float(0.0), Float(0.0),
+        ];
+        test_operation(expected, modulus);
+    }
+
+    #[test]
+    fn test_floor_div() {
+        let expected = vec![
+            Integer(1), Float(1.0), Float(1.0),
+            Float(1.0), Float(1.0), Float(1.0),
+            Float(1.0), Float(1.0), Float(1.0),
+        ];
+        test_operation(expected, fdiv);
+    }
+}

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -59,6 +59,10 @@ impl Interpreter {
                 FDiv(reg, ref lhs, ref rhs) => {
                     let res = fdiv(self.get_value(lhs), self.get_value(rhs));
                     self.registers[reg].set_value(res);
+                },
+                Exp(reg, ref lhs, ref rhs) => {
+                    let res = exp(self.get_value(lhs), self.get_value(rhs));
+                    self.registers[reg].set_value(res);
                 }
             }
             pc += 1;
@@ -80,7 +84,7 @@ mod tests {
     #[test]
     fn interpreter_works_correctly() {
         let mut regs = vec![];
-        for i in 0..7 {
+        for i in 0..8 {
             regs.push(i);
         }
         let instrs = vec![
@@ -97,6 +101,8 @@ mod tests {
                 Val::LuaValue(Value::Float(2.0))),
             FDiv(regs[6], Val::LuaValue(Value::Float(3.0)),
                  Val::LuaValue(Value::Float(2.0))),
+            Exp(regs[7], Val::LuaValue(Value::Float(1.0)),
+                 Val::LuaValue(Value::Float(2.0)))
         ];
         let bytecode = LuaBytecode::new(instrs, regs.len());
         let expected = vec![
@@ -104,6 +110,7 @@ mod tests {
             Value::Float(2.0),
             Value::Float(0.0),
             Value::Float(2.0),
+            Value::Float(1.0),
             Value::Float(1.0),
             Value::Float(1.0),
             Value::Float(1.0)

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,3 +1,4 @@
+mod arithmetic_operators;
 mod register;
 
 use bytecode::LuaBytecode;
@@ -5,6 +6,7 @@ use bytecode::instructions::Value;
 use bytecode::instructions::Val;
 use bytecode::instructions::Instr::*;
 use self::register::Reg;
+use self::arithmetic_operators::*;
 
 /// Represents a `LuaBytecode` interpreter.
 pub struct Interpreter {
@@ -35,39 +37,31 @@ impl Interpreter {
                     self.registers[reg].set_value(val);
                 },
                 Add(reg, ref lhs, ref rhs) => {
-                    let res = self.eval_arithmetic_op(&lhs, &rhs, lua_add);
+                    let res = add(self.get_value(lhs), self.get_value(rhs));
                     self.registers[reg].set_value(res);
                 },
                 Sub(reg, ref lhs, ref rhs) => {
-                    let res = self.eval_arithmetic_op(&lhs, &rhs, lua_sub);
+                    let res = sub(self.get_value(lhs), self.get_value(rhs));
                     self.registers[reg].set_value(res);
                 },
                 Mul(reg, ref lhs, ref rhs) => {
-                    let res = self.eval_arithmetic_op(&lhs, &rhs, lua_mul);
+                    let res = mul(self.get_value(lhs), self.get_value(rhs));
                     self.registers[reg].set_value(res);
                 },
                 Div(reg, ref lhs, ref rhs) => {
-                    let res = self.eval_arithmetic_op(&lhs, &rhs, lua_div);
+                    let res = div(self.get_value(lhs), self.get_value(rhs));
                     self.registers[reg].set_value(res);
                 },
                 Mod(reg, ref lhs, ref rhs) => {
-                    let res = self.eval_arithmetic_op(&lhs, &rhs, lua_mod);
+                    let res = modulus(self.get_value(lhs), self.get_value(rhs));
+                    self.registers[reg].set_value(res);
+                },
+                FDiv(reg, ref lhs, ref rhs) => {
+                    let res = fdiv(self.get_value(lhs), self.get_value(rhs));
                     self.registers[reg].set_value(res);
                 }
             }
             pc += 1;
-        }
-    }
-
-    /// Apply <op> to the given `Value`s.
-    fn eval_arithmetic_op(&self, lhs: &Val, rhs: &Val,
-                          op: fn(f64, f64) -> Value) -> Value {
-        let lhs = self.get_value(lhs);
-        let rhs = self.get_value(rhs);
-        match (lhs, rhs) {
-            (Value::Number(l), Value::Number(r)) => op(*l, *r),
-            (_, _) =>
-                panic!("Unable to perform arithmetic on {} and {}", lhs, rhs)
         }
     }
 
@@ -79,13 +73,6 @@ impl Interpreter {
     }
 }
 
-// Functions that are used in the interpreter in order to minimise duplication
-fn lua_add(lhs: f64, rhs: f64) -> Value { Value::Number(lhs + rhs) }
-fn lua_sub(lhs: f64, rhs: f64) -> Value { Value::Number(lhs - rhs) }
-fn lua_mul(lhs: f64, rhs: f64) -> Value { Value::Number(lhs * rhs) }
-fn lua_div(lhs: f64, rhs: f64) -> Value { Value::Number(lhs / rhs) }
-fn lua_mod(lhs: f64, rhs: f64) -> Value { Value::Number(lhs % rhs) }
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -93,30 +80,33 @@ mod tests {
     #[test]
     fn interpreter_works_correctly() {
         let mut regs = vec![];
-        for i in 0..6 {
+        for i in 0..7 {
             regs.push(i);
         }
         let instrs = vec![
-            Mov(regs[0], Val::LuaValue(Value::Number(0.0))),
-            Add(regs[1], Val::LuaValue(Value::Number(1.0)),
-                Val::LuaValue(Value::Number(1.0))),
-            Sub(regs[2], Val::LuaValue(Value::Number(1.0)),
-                Val::LuaValue(Value::Number(1.0))),
-            Mul(regs[3], Val::LuaValue(Value::Number(1.0)),
-                Val::LuaValue(Value::Number(2.0))),
-            Div(regs[4], Val::LuaValue(Value::Number(2.0)),
-                Val::LuaValue(Value::Number(2.0))),
-            Mod(regs[5], Val::LuaValue(Value::Number(3.0)),
-                Val::LuaValue(Value::Number(2.0))),
+            Mov(regs[0], Val::LuaValue(Value::Float(0.0))),
+            Add(regs[1], Val::LuaValue(Value::Float(1.0)),
+                Val::LuaValue(Value::Float(1.0))),
+            Sub(regs[2], Val::LuaValue(Value::Float(1.0)),
+                Val::LuaValue(Value::Float(1.0))),
+            Mul(regs[3], Val::LuaValue(Value::Float(1.0)),
+                Val::LuaValue(Value::Float(2.0))),
+            Div(regs[4], Val::LuaValue(Value::Float(2.0)),
+                Val::LuaValue(Value::Float(2.0))),
+            Mod(regs[5], Val::LuaValue(Value::Float(3.0)),
+                Val::LuaValue(Value::Float(2.0))),
+            FDiv(regs[6], Val::LuaValue(Value::Float(3.0)),
+                 Val::LuaValue(Value::Float(2.0))),
         ];
         let bytecode = LuaBytecode::new(instrs, regs.len());
         let expected = vec![
-            Value::Number(0.0),
-            Value::Number(2.0),
-            Value::Number(0.0),
-            Value::Number(2.0),
-            Value::Number(1.0),
-            Value::Number(1.0),
+            Value::Float(0.0),
+            Value::Float(2.0),
+            Value::Float(0.0),
+            Value::Float(2.0),
+            Value::Float(1.0),
+            Value::Float(1.0),
+            Value::Float(1.0)
         ];
 
         let mut interpreter = Interpreter::new(bytecode);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,11 @@ impl LuaParseTree {
             Term{lexeme} => {
                 let value = self.get_string(lexeme.start(), lexeme.end());
                 if lexeme.tok_id() == lua5_3_l::T_NUMERAL {
-                    LuaValue(Value::Number(value.parse().unwrap()))
+                    LuaValue(if value.contains(".") {
+                        Value::Float(value.parse().unwrap())
+                    } else {
+                        Value::Integer(value.parse().unwrap())
+                    })
                 } else {
                     let reg = reg_map.get_reg(value);
                     Register(reg)


### PR DESCRIPTION
The Number type is now split into `Integer` and `Float`.

The arithmetic operators need to convert their arguments in certain
circumstances (e.g. when adding a `float` to an `int`, both arguments are converted
to `float`). The operator implementations were also moved into their own module.

Only binary operations are supported, which means that `x = -1` is not supported. 
Support for this will be added in a future PR because the compiler needs to be refactored
first.

This PR also adds extra test cases.