### PR TITLE
Redesign the lua vm.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 
 members = [
-    "luacompiler"
+    "luacompiler",
+    "luavm"
 ]

--- a/luavm/Cargo.toml
+++ b/luavm/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "luavm"
+version = "0.1.0"
+authors = ["Robert Bartlensky <bartlensky.robert@gmail.com>"]
+
+[lib]
+name = "luavm"
+path = "src/lib/mod.rs"
+
+[dependencies]
+luacompiler = { path="../luacompiler" }
+
+[dependencies.clap]
+version = "2.32"
+default-features = false

--- a/luavm/src/lib/instructions/arithmetic_operators.rs
+++ b/luavm/src/lib/instructions/arithmetic_operators.rs
@@ -1,0 +1,102 @@
+use lua_value::*;
+use luacompiler::bytecode::instructions::{first_arg, second_arg, third_arg};
+use Vm;
+
+/// Perform <op> on the arguments of <instr>. The arguments are converted using
+/// the rules of Lua.
+macro_rules! bin_op {
+    ($vm:ident, $instr: ident, $op: tt) => {
+        {
+            let lhs = &$vm.registers[second_arg($instr) as usize];
+            let rhs = &$vm.registers[third_arg($instr) as usize];
+            if lhs.is_float() || rhs.is_float() {
+                let float = match (lhs.to_float(), rhs.to_float()) {
+                    (Some(l), Some(r)) => l $op r,
+                    (_, _) => panic!("Failed to convert to float!")
+                };
+                Box::new(LuaFloat::new(float))
+            } else {
+                let int = match (lhs.to_int(), rhs.to_int()) {
+                    (Some(l), Some(r)) => l $op r,
+                    (_, _) => panic!("Failed to convert to int!")
+                };
+                Box::new(LuaInt::new(int))
+            }
+        }
+    }
+}
+
+/// Perform <op> on the argmuents of <instr>. The arguments are always converted to
+/// float.
+macro_rules! float_bin_op {
+    ($vm:ident, $instr: ident, $op: tt) => {
+        {
+            let lhs = &$vm.registers[second_arg($instr) as usize];
+            let rhs = &$vm.registers[third_arg($instr) as usize];
+            let float = match (lhs.to_float(), rhs.to_float()) {
+                (Some(l), Some(r)) => l $op r,
+                (_, _) => panic!("Failed to convert to float!")
+            };
+            Box::new(LuaFloat::new(float))
+        }
+    }
+}
+
+pub fn add(vm: &mut Vm, instr: u32) {
+    let res: Box<LuaValue> = bin_op!(vm, instr, +);
+    vm.registers[first_arg(instr) as usize] = res;
+}
+
+pub fn sub(vm: &mut Vm, instr: u32) {
+    let res: Box<LuaValue> = bin_op!(vm, instr, -);
+    vm.registers[first_arg(instr) as usize] = res;
+}
+
+pub fn mul(vm: &mut Vm, instr: u32) {
+    let res: Box<LuaValue> = bin_op!(vm, instr, *);
+    vm.registers[first_arg(instr) as usize] = res;
+}
+
+pub fn div(vm: &mut Vm, instr: u32) {
+    let res: Box<LuaValue> = float_bin_op!(vm, instr, /);
+    vm.registers[first_arg(instr) as usize] = res;
+}
+
+pub fn modulus(vm: &mut Vm, instr: u32) {
+    let res: Box<LuaValue> = bin_op!(vm, instr, %);
+    vm.registers[first_arg(instr) as usize] = res;
+}
+
+pub fn fdiv(vm: &mut Vm, instr: u32) {
+    let res: Box<LuaValue> = {
+        let lhs = &vm.registers[second_arg(instr) as usize];
+        let rhs = &vm.registers[third_arg(instr) as usize];
+        if lhs.is_float() || rhs.is_float() {
+            let float = match (lhs.to_float(), rhs.to_float()) {
+                (Some(l), Some(r)) => (l / r).floor(),
+                (_, _) => panic!("Failed to convert to float!"),
+            };
+            Box::new(LuaFloat::new(float))
+        } else {
+            let int = match (lhs.to_int(), rhs.to_int()) {
+                (Some(l), Some(r)) => l / r,
+                (_, _) => panic!("Failed to convert to int!"),
+            };
+            Box::new(LuaInt::new(int))
+        }
+    };
+    vm.registers[first_arg(instr) as usize] = res;
+}
+
+pub fn exp(vm: &mut Vm, instr: u32) {
+    let res: Box<LuaValue> = {
+        let lhs = &vm.registers[second_arg(instr) as usize];
+        let rhs = &vm.registers[third_arg(instr) as usize];
+        let float = match (lhs.to_float(), rhs.to_float()) {
+            (Some(l), Some(r)) => l.powf(r),
+            (_, _) => panic!("Failed to convert to float!"),
+        };
+        Box::new(LuaFloat::new(float))
+    };
+    vm.registers[first_arg(instr) as usize] = res;
+}

--- a/luavm/src/lib/instructions/loads.rs
+++ b/luavm/src/lib/instructions/loads.rs
@@ -1,0 +1,24 @@
+use lua_value::*;
+use luacompiler::bytecode::instructions::{first_arg, second_arg};
+use Vm;
+
+pub fn mov(vm: &mut Vm, instr: u32) {
+    let i = first_arg(instr) as usize;
+    let j = second_arg(instr) as usize;
+    vm.registers[i] = vm.registers[j].clone();
+}
+
+pub fn ldi(vm: &mut Vm, instr: u32) {
+    let val = vm.bytecode.get_int(second_arg(instr));
+    vm.registers[first_arg(instr) as usize] = Box::new(LuaInt::new(val));
+}
+
+pub fn ldf(vm: &mut Vm, instr: u32) {
+    let val = vm.bytecode.get_float(second_arg(instr));
+    vm.registers[first_arg(instr) as usize] = Box::new(LuaFloat::new(val));
+}
+
+pub fn lds(vm: &mut Vm, instr: u32) {
+    let val = vm.bytecode.get_string(second_arg(instr));
+    vm.registers[first_arg(instr) as usize] = Box::new(LuaString::new(val.to_string()));
+}

--- a/luavm/src/lib/instructions/mod.rs
+++ b/luavm/src/lib/instructions/mod.rs
@@ -1,0 +1,2 @@
+pub mod arithmetic_operators;
+pub mod loads;

--- a/luavm/src/lib/lua_value.rs
+++ b/luavm/src/lib/lua_value.rs
@@ -1,0 +1,141 @@
+/// Super trait which helps with cloning `Box<LuaValue>`s.
+pub trait LuaValueClone {
+    fn clone_box(&self) -> Box<LuaValue>;
+}
+
+/// Represents a value in Lua.
+pub trait LuaValue: LuaValueClone {
+    fn to_int(&self) -> Option<i64> {
+        None
+    }
+
+    fn is_float(&self) -> bool {
+        false
+    }
+
+    fn to_float(&self) -> Option<f64> {
+        None
+    }
+}
+
+impl<T> LuaValueClone for T
+where
+    T: 'static + LuaValue + Clone,
+{
+    fn clone_box(&self) -> Box<LuaValue> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<LuaValue> {
+    fn clone(&self) -> Box<LuaValue> {
+        self.clone_box()
+    }
+}
+
+#[derive(Clone)]
+pub struct LuaNil {}
+
+impl LuaValue for LuaNil {}
+
+#[derive(Clone)]
+pub struct LuaInt {
+    v: i64,
+}
+
+impl LuaInt {
+    pub fn new(v: i64) -> LuaInt {
+        LuaInt { v }
+    }
+}
+
+impl LuaValue for LuaInt {
+    fn to_int(&self) -> Option<i64> {
+        Some(self.v)
+    }
+
+    fn to_float(&self) -> Option<f64> {
+        Some(self.v as f64)
+    }
+}
+
+#[derive(Clone)]
+pub struct LuaFloat {
+    v: f64,
+}
+
+impl LuaFloat {
+    pub fn new(v: f64) -> LuaFloat {
+        LuaFloat { v }
+    }
+}
+
+impl LuaValue for LuaFloat {
+    fn is_float(&self) -> bool {
+        true
+    }
+
+    fn to_float(&self) -> Option<f64> {
+        Some(self.v)
+    }
+}
+
+#[derive(Clone)]
+pub struct LuaString {
+    v: String,
+}
+
+impl LuaString {
+    pub fn new(v: String) -> LuaString {
+        LuaString { v }
+    }
+}
+
+impl LuaValue for LuaString {
+    fn is_float(&self) -> bool {
+        true
+    }
+
+    fn to_float(&self) -> Option<f64> {
+        self.v.parse().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lua_nil() {
+        let ln = LuaNil {};
+        assert!(!ln.is_float());
+        assert!(ln.to_float().is_none());
+        assert!(ln.to_int().is_none());
+    }
+
+    #[test]
+    fn lua_int() {
+        let li = LuaInt::new(2);
+        assert!(!li.is_float());
+        assert!(li.to_float().is_some());
+        assert_eq!(li.to_int(), Some(2));
+    }
+
+    #[test]
+    fn lua_float() {
+        let lf = LuaFloat::new(0.0);
+        assert!(lf.is_float());
+        assert!(lf.to_float().is_some());
+        assert!(lf.to_int().is_none());
+    }
+
+    #[test]
+    fn lua_string() {
+        let ls = LuaString::new("Foo".to_string());
+        assert!(ls.is_float());
+        assert!(ls.to_float().is_none());
+        assert!(ls.to_int().is_none());
+        let ls = LuaString::new("0.0".to_string());
+        assert!(ls.to_float().is_some());
+    }
+}

--- a/luavm/src/lib/mod.rs
+++ b/luavm/src/lib/mod.rs
@@ -1,0 +1,44 @@
+extern crate luacompiler;
+
+mod instructions;
+mod lua_value;
+
+use instructions::{arithmetic_operators::*, loads::*};
+use lua_value::{LuaNil, LuaValue};
+use luacompiler::bytecode::{instructions::opcode, LuaBytecode};
+
+/// The instruction handler for each opcode.
+const OPCODE_HANDLER: &'static [fn(&mut Vm, u32)] =
+    &[mov, ldi, ldf, lds, add, sub, mul, div, modulus, fdiv, exp];
+
+/// Represents a `LuaBytecode` interpreter.
+pub struct Vm {
+    pub bytecode: LuaBytecode,
+    pub registers: Vec<Box<LuaValue>>,
+}
+
+impl Vm {
+    /// Create a new interpreter for the given bytecode.
+    pub fn new(bytecode: LuaBytecode) -> Vm {
+        let regs = bytecode.reg_count();
+        let mut registers: Vec<Box<LuaValue>> = Vec::with_capacity(regs as usize);
+        for _ in 0..regs {
+            registers.push(Box::new(LuaNil {}));
+        }
+        Vm {
+            bytecode,
+            registers,
+        }
+    }
+
+    /// Evaluate the program.
+    pub fn eval(&mut self) {
+        let mut pc = 0;
+        let len = self.bytecode.instrs_len();
+        while pc < len {
+            let instr = self.bytecode.get_instr(pc);
+            (OPCODE_HANDLER[opcode(instr) as usize])(self, instr);
+            pc += 1;
+        }
+    }
+}

--- a/luavm/src/main.rs
+++ b/luavm/src/main.rs
@@ -1,0 +1,32 @@
+extern crate clap;
+extern crate luacompiler;
+extern crate luavm;
+
+use clap::{App, Arg};
+use luacompiler::LuaParseTree;
+use luavm::Vm;
+
+fn main() {
+    let matches = App::new("Lua interpreter")
+        .version("0.1")
+        .author("Robert Bartlensky")
+        .about("Interpret Lua files")
+        .arg(
+            Arg::with_name("INPUT")
+                .help("File to interpret")
+                .required(true)
+                .index(1),
+        )
+        .get_matches();
+    // we can safely unwrap because INPUT is not an optional argument
+    let file = matches.value_of("INPUT").unwrap();
+    let parse_tree = LuaParseTree::new(&file);
+    match parse_tree {
+        Ok(pt) => {
+            let bc = pt.compile_to_ir();
+            let mut vm = Vm::new(bc);
+            vm.eval();
+        }
+        Err(err) => println!("{:#?}", err),
+    }
+}


### PR DESCRIPTION
The interpreter has been moved into its own crate.
The new vm takes a different approach when
executing instructions. Instead of matching the
opcode of the instruction, the interpreter
calls the function that is associated to the
opcode.
Other changes include:
* Removal of the `Reg` structure
* An executable which reads in a lua file, and
interprets it
* Some additional unit-tests