### PR TITLE
SSA intermediate representation

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,2 @@
-indent_style="Block"
-imports_indent="Block"
 use_try_shorthand=true
 use_field_init_shorthand=true
-merge_imports=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-rust: nightly
 before_script:
   - rustup component add rustfmt-preview
 script:

--- a/luacompiler/build.rs
+++ b/luacompiler/build.rs
@@ -5,7 +5,8 @@ use lrlex::LexerBuilder;
 use lrpar::CTParserBuilder;
 
 fn main() -> Result<(), Box<std::error::Error>> {
-    let lex_rule_ids_map = CTParserBuilder::<u8>::new().process_file_in_src("lua5_3/lua5_3.y")?;
+    let lex_rule_ids_map =
+        CTParserBuilder::<u8>::new_with_storaget().process_file_in_src("lua5_3/lua5_3.y")?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)
         .process_file_in_src("lua5_3/lua5_3.l")?;

--- a/luacompiler/src/lib/bytecode/instructions.rs
+++ b/luacompiler/src/lib/bytecode/instructions.rs
@@ -28,10 +28,11 @@ pub fn make_instr(opcode: Opcode, arg1: u8, arg2: u8, arg3: u8) -> u32 {
 /// Represents a high level instruction whose operands have a size of usize.
 /// This is used by the frontend to create an SSA IR, which later gets translated
 /// into smaller instructions that fit in 32 bits.
+#[derive(PartialEq, Eq, Debug)]
 pub struct HLInstr(pub Opcode, pub usize, pub usize, pub usize);
 
 impl HLInstr {
-    pub fn to_32bit(&self) -> u32 {
+    pub fn as_32bit(&self) -> u32 {
         if self.1 > 255 || self.2 > 255 || self.3 > 255 {
             panic!("Value is truncated!");
         }
@@ -43,7 +44,7 @@ impl HLInstr {
 /// Each operation can have at most 3 arguments.
 /// There are 256 available registers, and load operations (LDI, LDF, LDS) can only
 /// refer to at most 256 constants.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Opcode {
     MOV = 0,  // R(1) = R(2)
     LDI = 1,  // R(1) = I(1); load integer from the constant table

--- a/luacompiler/src/lib/bytecode/instructions.rs
+++ b/luacompiler/src/lib/bytecode/instructions.rs
@@ -25,10 +25,25 @@ pub fn make_instr(opcode: Opcode, arg1: u8, arg2: u8, arg3: u8) -> u32 {
     opcode as u32 + ((arg1 as u32) << 4) + ((arg2 as u32) << 8) + ((arg3 as u32) << 12)
 }
 
+/// Represents a high level instruction whose operands have a size of usize.
+/// This is used by the frontend to create an SSA IR, which later gets translated
+/// into smaller instructions that fit in 32 bits.
+pub struct HLInstr(pub Opcode, pub usize, pub usize, pub usize);
+
+impl HLInstr {
+    pub fn to_32bit(&self) -> u32 {
+        if self.1 > 255 || self.2 > 255 || self.3 > 255 {
+            panic!("Value is truncated!");
+        }
+        make_instr(self.0, self.1 as u8, self.2 as u8, self.3 as u8)
+    }
+}
+
 /// Represents the supported operations of the bytecode.
 /// Each operation can have at most 3 arguments.
 /// There are 256 available registers, and load operations (LDI, LDF, LDS) can only
 /// refer to at most 256 constants.
+#[derive(Clone, Copy)]
 pub enum Opcode {
     MOV = 0,  // R(1) = R(2)
     LDI = 1,  // R(1) = I(1); load integer from the constant table

--- a/luacompiler/src/lib/bytecode/mod.rs
+++ b/luacompiler/src/lib/bytecode/mod.rs
@@ -84,9 +84,9 @@ impl LuaBytecode {
 
 impl fmt::Display for LuaBytecode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{{\n");
+        write!(f, "{{\n")?;
         for instr in &self.block {
-            write!(f, "  {}\n", instr);
+            write!(f, "  {}\n", instr)?;
         }
         write!(f, "}}")
     }

--- a/luacompiler/src/lib/bytecodegen/mod.rs
+++ b/luacompiler/src/lib/bytecodegen/mod.rs
@@ -16,8 +16,9 @@ impl LuaIRToLuaBc {
     }
 
     fn compile(self) -> LuaBytecode {
+        assert!(self.ir.lifetimes.len() < 256);
         LuaBytecode::new(
-            self.ir.instrs.iter().map(|i| i.to_32bit()).collect(),
+            self.ir.instrs.iter().map(|i| i.as_32bit()).collect(),
             self.ir.const_map,
             self.ir.lifetimes.len() as u8,
         )

--- a/luacompiler/src/lib/bytecodegen/mod.rs
+++ b/luacompiler/src/lib/bytecodegen/mod.rs
@@ -1,0 +1,25 @@
+use bytecode::LuaBytecode;
+use irgen::lua_ir::LuaIR;
+
+pub fn compile_to_bytecode(ir: LuaIR) -> LuaBytecode {
+    LuaIRToLuaBc::new(ir).compile()
+}
+
+struct LuaIRToLuaBc {
+    ir: LuaIR,
+}
+
+impl LuaIRToLuaBc {
+    /// Compile the given LuaIR to LuaBytecode.
+    fn new(ir: LuaIR) -> LuaIRToLuaBc {
+        LuaIRToLuaBc { ir }
+    }
+
+    fn compile(self) -> LuaBytecode {
+        LuaBytecode::new(
+            self.ir.instrs.iter().map(|i| i.to_32bit()).collect(),
+            self.ir.const_map,
+            self.ir.lifetimes.len() as u8,
+        )
+    }
+}

--- a/luacompiler/src/lib/errors.rs
+++ b/luacompiler/src/lib/errors.rs
@@ -1,4 +1,4 @@
-use lrpar::{Node, ParseError};
+use lrpar::{LexParseError, Node, ParseError};
 use std::io;
 
 type ParseErr = (Option<Node<u8>>, Vec<ParseError<u8>>);
@@ -6,12 +6,12 @@ type ParseErr = (Option<Node<u8>>, Vec<ParseError<u8>>);
 #[derive(Debug)]
 pub enum CliError {
     Io(io::Error),
-    LexError(lrpar::LexParseError<u8>),
+    LexError(Vec<LexParseError<u8>>),
     ParseError(ParseErr),
 }
 
-impl From<lrpar::LexParseError<u8>> for CliError {
-    fn from(err: lrpar::LexParseError<u8>) -> CliError {
+impl From<Vec<LexParseError<u8>>> for CliError {
+    fn from(err: Vec<LexParseError<u8>>) -> CliError {
         CliError::LexError(err)
     }
 }

--- a/luacompiler/src/lib/irgen/constants_map.rs
+++ b/luacompiler/src/lib/irgen/constants_map.rs
@@ -9,9 +9,9 @@ use std::collections::HashMap;
 /// For instance, if '1.0' is used in Lua, then an entry from 1.0 to 0 is created in the
 /// <float_map> member.
 pub struct ConstantsMap {
-    int_map: HashMap<i64, u8>,
-    float_map: HashMap<String, u8>,
-    str_map: HashMap<String, u8>,
+    int_map: HashMap<i64, usize>,
+    float_map: HashMap<String, usize>,
+    str_map: HashMap<String, usize>,
 }
 
 impl ConstantsMap {
@@ -25,8 +25,8 @@ impl ConstantsMap {
     }
 
     /// Get the corresponding index of the given integer in the constant table.
-    pub fn get_int(&mut self, int: i64) -> u8 {
-        let len = self.int_map.len() as u8;
+    pub fn get_int(&mut self, int: i64) -> usize {
+        let len = self.int_map.len();
         *self.int_map.entry(int).or_insert(len)
     }
 
@@ -41,8 +41,8 @@ impl ConstantsMap {
     }
 
     /// Get the corresponding index of the given float in the constant table.
-    pub fn get_float(&mut self, float: String) -> u8 {
-        let len = self.float_map.len() as u8;
+    pub fn get_float(&mut self, float: String) -> usize {
+        let len = self.float_map.len();
         *self.float_map.entry(float).or_insert(len)
     }
 
@@ -57,8 +57,8 @@ impl ConstantsMap {
     }
 
     /// Get the corresponding index of the given string in the constant table.
-    pub fn get_str(&mut self, string: String) -> u8 {
-        let len = self.str_map.len() as u8;
+    pub fn get_str(&mut self, string: String) -> usize {
+        let len = self.str_map.len();
         *self.str_map.entry(string).or_insert(len)
     }
 

--- a/luacompiler/src/lib/irgen/lua_ir.rs
+++ b/luacompiler/src/lib/irgen/lua_ir.rs
@@ -1,0 +1,24 @@
+use bytecode::instructions::HLInstr;
+use irgen::{constants_map::ConstantsMap, register_map::Lifetime};
+
+/// Represents an IR in which all instructions are in SSA form.
+pub struct LuaIR {
+    pub instrs: Vec<HLInstr>,
+    pub const_map: ConstantsMap,
+    pub lifetimes: Vec<Lifetime>,
+}
+
+impl LuaIR {
+    pub fn new(
+        instrs: Vec<HLInstr>,
+        const_map: ConstantsMap,
+        mut lifetimes: Vec<Lifetime>,
+    ) -> LuaIR {
+        lifetimes.sort_by(|x, y| x.start_point().cmp(&y.start_point()));
+        LuaIR {
+            instrs,
+            const_map,
+            lifetimes,
+        }
+    }
+}

--- a/luacompiler/src/lib/irgen/mod.rs
+++ b/luacompiler/src/lib/irgen/mod.rs
@@ -77,7 +77,9 @@ impl<'a> LuaToIR<'a> {
     fn compile_variable(&self, node: &Node<u8>) -> &'a str {
         let name = LuaToIR::find_term(node, lua5_3_l::T_NAME);
         match name {
-            Some(Term { lexeme }) => self.pt.get_string(lexeme.start(), lexeme.end()),
+            Some(Term { lexeme }) => self
+                .pt
+                .get_string(lexeme.start(), lexeme.end().unwrap_or(lexeme.start())),
             _ => {
                 panic!("Must have assignments of form: var = expr!");
             }
@@ -105,7 +107,9 @@ impl<'a> LuaToIR<'a> {
                 }
             }
             Term { lexeme } => {
-                let value = self.pt.get_string(lexeme.start(), lexeme.end());
+                let value = self
+                    .pt
+                    .get_string(lexeme.start(), lexeme.end().unwrap_or(lexeme.start()));
                 match lexeme.tok_id() {
                     lua5_3_l::T_NUMERAL => {
                         let reg = self.reg_map.get_new_reg();

--- a/luacompiler/src/lib/irgen/mod.rs
+++ b/luacompiler/src/lib/irgen/mod.rs
@@ -2,7 +2,7 @@ pub mod constants_map;
 pub mod register_map;
 use self::{constants_map::ConstantsMap, register_map::RegisterMap};
 use bytecode::{
-    instructions::{make_instr, Opcode},
+    instructions::{HLInstr, Opcode},
     LuaBytecode,
 };
 use cfgrammar::RIdx;
@@ -16,9 +16,9 @@ use LuaParseTree;
 /// representation, which is easier to translate to the current bytecode.
 pub struct LuaToBytecode<'a> {
     pt: &'a LuaParseTree,
-    reg_map: RegisterMap,
+    reg_map: RegisterMap<'a>,
     const_map: ConstantsMap,
-    instrs: Vec<u32>,
+    instrs: Vec<HLInstr>,
 }
 
 impl<'a> LuaToBytecode<'a> {
@@ -45,8 +45,15 @@ impl<'a> LuaToBytecode<'a> {
                     match nodes[1] {
                         Term { lexeme } if lexeme.tok_id() == lua5_3_l::T_EQ => {
                             let value = self.compile_expr(&nodes[2]);
-                            let reg = self.reg_map.get_reg(self.compile_variable(&nodes[0]));
-                            self.instrs.push(make_instr(Opcode::MOV, reg, value, 0));
+                            let name = self.compile_variable(&nodes[0]);
+                            // because we are creating an IR which is in SSA form, it
+                            // means that each assignment creates a new register
+                            let reg = self.reg_map.get_new_reg();
+                            // if a variable is assigned a value multiple times, we have
+                            // to make sure that the map knows the new register which
+                            // holds the new value
+                            self.reg_map.set_reg(name, reg);
+                            self.add_instr(HLInstr(Opcode::MOV, reg, value, 0));
                         }
                         _ => {}
                     }
@@ -61,11 +68,15 @@ impl<'a> LuaToBytecode<'a> {
                 }
             }
         }
-        LuaBytecode::new(self.instrs, self.const_map, self.reg_map.reg_count())
+        LuaBytecode::new(
+            self.instrs.iter().map(|i| i.to_32bit()).collect(),
+            self.const_map,
+            self.reg_map.reg_count() as u8,
+        )
     }
 
     /// Jumps to the first child of <node> which denotes a variable name.
-    fn compile_variable(&'a self, node: &Node<u8>) -> &'a str {
+    fn compile_variable(&self, node: &Node<u8>) -> &'a str {
         let name = LuaToBytecode::find_term(node, lua5_3_l::T_NAME);
         match name {
             Some(Term { lexeme }) => self.pt.get_string(lexeme.start(), lexeme.end()),
@@ -77,7 +88,7 @@ impl<'a> LuaToBytecode<'a> {
 
     /// Compile the expression rooted at <node>. Any instructions that are created are
     /// simply added to the bytecode that is being generated.
-    fn compile_expr(&mut self, node: &Node<u8>) -> u8 {
+    fn compile_expr(&mut self, node: &Node<u8>) -> usize {
         match *node {
             Nonterm {
                 ridx: RIdx(_ridx),
@@ -89,9 +100,9 @@ impl<'a> LuaToBytecode<'a> {
                     debug_assert!(nodes.len() == 3);
                     let left = self.compile_expr(&nodes[0]);
                     let right = self.compile_expr(&nodes[2]);
-                    let new_var = self.reg_map.new_reg();
+                    let new_var = self.reg_map.get_new_reg();
                     let instr = self.get_instr(&nodes[1], new_var, left, right);
-                    self.instrs.push(instr);
+                    self.add_instr(instr);
                     new_var
                 }
             }
@@ -99,22 +110,22 @@ impl<'a> LuaToBytecode<'a> {
                 let value = self.pt.get_string(lexeme.start(), lexeme.end());
                 match lexeme.tok_id() {
                     lua5_3_l::T_NUMERAL => {
-                        let reg = self.reg_map.new_reg();
+                        let reg = self.reg_map.get_new_reg();
                         if value.contains(".") {
                             let fl = self.const_map.get_float(value.to_string());
-                            self.instrs.push(make_instr(Opcode::LDF, reg, fl, 0));
+                            self.add_instr(HLInstr(Opcode::LDF, reg, fl, 0));
                         } else {
                             let int = self.const_map.get_int(value.parse().unwrap());
-                            self.instrs.push(make_instr(Opcode::LDI, reg, int, 0));
+                            self.add_instr(HLInstr(Opcode::LDI, reg, int, 0));
                         }
                         reg
                     }
                     lua5_3_l::T_SHORT_STR => {
-                        let reg = self.reg_map.new_reg();
+                        let reg = self.reg_map.get_new_reg();
                         let len = value.len();
                         // make sure that the quotes are not included!
                         let short_str = self.const_map.get_str(value[1..(len - 1)].to_string());
-                        self.instrs.push(make_instr(Opcode::LDS, reg, short_str, 0));
+                        self.add_instr(HLInstr(Opcode::LDS, reg, short_str, 0));
                         reg
                     }
                     _ => self.reg_map.get_reg(value),
@@ -124,7 +135,7 @@ impl<'a> LuaToBytecode<'a> {
     }
 
     /// Get the appropriate instruction for a given Node::Term.
-    fn get_instr(&self, node: &Node<u8>, reg: u8, lreg: u8, rreg: u8) -> u32 {
+    fn get_instr(&self, node: &Node<u8>, reg: usize, lreg: usize, rreg: usize) -> HLInstr {
         if let Term { lexeme } = node {
             let opcode = match lexeme.tok_id() {
                 lua5_3_l::T_PLUS => Opcode::ADD,
@@ -136,7 +147,7 @@ impl<'a> LuaToBytecode<'a> {
                 lua5_3_l::T_CARET => Opcode::EXP,
                 _ => unimplemented!("Instruction {}", lexeme.tok_id()),
             };
-            make_instr(opcode, reg, lreg, rreg)
+            HLInstr(opcode, reg, lreg, rreg)
         } else {
             panic!("Expected a Node::Term!");
         }
@@ -161,5 +172,12 @@ impl<'a> LuaToBytecode<'a> {
             }
         }
         None
+    }
+
+    /// Add the given instruction to the list of all instructions, and step register
+    /// lifetimes.
+    fn add_instr(&mut self, instr: HLInstr) {
+        self.instrs.push(instr);
+        self.reg_map.step();
     }
 }

--- a/luacompiler/src/lib/irgen/mod.rs
+++ b/luacompiler/src/lib/irgen/mod.rs
@@ -1,29 +1,31 @@
 pub mod constants_map;
+pub mod lua_ir;
 pub mod register_map;
-use self::{constants_map::ConstantsMap, register_map::RegisterMap};
-use bytecode::{
-    instructions::{HLInstr, Opcode},
-    LuaBytecode,
-};
+
+use self::{constants_map::ConstantsMap, lua_ir::LuaIR, register_map::RegisterMap};
+use bytecode::instructions::{HLInstr, Opcode};
 use cfgrammar::RIdx;
 use lrpar::Node::{self, *};
 use lua5_3_l;
 use lua5_3_y;
 use LuaParseTree;
 
-/// Represents a compiler which translates a given Lua parse tree to some bytecode representation.
-/// This compiler will be changed in the future to translate from lua to a higher-level
-/// representation, which is easier to translate to the current bytecode.
-pub struct LuaToBytecode<'a> {
+/// Compile the given parse tree into an SSA IR.
+pub fn compile_to_ir(pt: &LuaParseTree) -> LuaIR {
+    LuaToIR::new(pt).compile()
+}
+
+/// Represents a compiler which translates a given Lua parse tree to an SSA IR.
+struct LuaToIR<'a> {
     pt: &'a LuaParseTree,
     reg_map: RegisterMap<'a>,
     const_map: ConstantsMap,
     instrs: Vec<HLInstr>,
 }
 
-impl<'a> LuaToBytecode<'a> {
-    pub fn new(pt: &'a LuaParseTree) -> LuaToBytecode {
-        LuaToBytecode {
+impl<'a> LuaToIR<'a> {
+    fn new(pt: &'a LuaParseTree) -> LuaToIR {
+        LuaToIR {
             pt,
             reg_map: RegisterMap::new(),
             const_map: ConstantsMap::new(),
@@ -32,7 +34,7 @@ impl<'a> LuaToBytecode<'a> {
     }
 
     /// Compile the parse tree to an intermediate representation.
-    pub fn compile(mut self) -> LuaBytecode {
+    pub fn compile(mut self) -> LuaIR {
         let mut pt_nodes = vec![&self.pt.tree];
         while !pt_nodes.is_empty() {
             let node = pt_nodes.pop().unwrap();
@@ -68,16 +70,12 @@ impl<'a> LuaToBytecode<'a> {
                 }
             }
         }
-        LuaBytecode::new(
-            self.instrs.iter().map(|i| i.to_32bit()).collect(),
-            self.const_map,
-            self.reg_map.reg_count() as u8,
-        )
+        LuaIR::new(self.instrs, self.const_map, self.reg_map.get_lifetimes())
     }
 
     /// Jumps to the first child of <node> which denotes a variable name.
     fn compile_variable(&self, node: &Node<u8>) -> &'a str {
-        let name = LuaToBytecode::find_term(node, lua5_3_l::T_NAME);
+        let name = LuaToIR::find_term(node, lua5_3_l::T_NAME);
         match name {
             Some(Term { lexeme }) => self.pt.get_string(lexeme.start(), lexeme.end()),
             _ => {

--- a/luacompiler/src/lib/irgen/register_map.rs
+++ b/luacompiler/src/lib/irgen/register_map.rs
@@ -177,7 +177,7 @@ mod tests {
     #[test]
     fn registers_are_retrieved_in_the_correct_order() {
         let mut rm = RegisterMap::new();
-        for i in 0..3 {
+        for _ in 0..3 {
             rm.push_scope();
             rm.create_reg("foo");
         }

--- a/luacompiler/src/lib/irgen/register_map.rs
+++ b/luacompiler/src/lib/irgen/register_map.rs
@@ -76,6 +76,10 @@ impl<'a> RegisterMap<'a> {
     pub fn reg_count(self) -> usize {
         self.lifetimes.len()
     }
+
+    pub fn get_lifetimes(self) -> Vec<Lifetime> {
+        self.lifetimes
+    }
 }
 
 #[cfg(test)]

--- a/luacompiler/src/lib/irgen/register_map.rs
+++ b/luacompiler/src/lib/irgen/register_map.rs
@@ -31,32 +31,58 @@ impl Lifetime {
 }
 
 /// Represents a structure that is used to map Lua variables to registers, and to keep
-/// track of their lifetimes. Each Lua file has its own register map.
+/// track of their lifetimes. Each Lua module has its own register map.
 pub struct RegisterMap<'a> {
     lifetimes: Vec<Lifetime>,
-    reg_map: HashMap<&'a str, usize>,
+    reg_maps: Vec<HashMap<&'a str, usize>>,
 }
 
 impl<'a> RegisterMap<'a> {
     pub fn new() -> RegisterMap<'a> {
         RegisterMap {
             lifetimes: vec![],
-            reg_map: HashMap::new(),
+            // the first map holds the variables of the module
+            reg_maps: vec![HashMap::new()],
         }
     }
 
-    /// Creates and returns a new register, whose lifetime begins from self.current_instr.
+    /// Pushes a new map of registers. All new registers will be allocated in the newly
+    /// created map.
+    pub fn push_scope(&mut self) {
+        self.reg_maps.push(HashMap::new());
+    }
+
+    /// Pops the last map of registers.
+    pub fn pop_scope(&mut self) {
+        self.reg_maps.pop();
+    }
+
+    /// Creates and returns a new register.
     pub fn get_new_reg(&mut self) -> usize {
         let lifetime = Lifetime::new(self.lifetimes.len());
         self.lifetimes.push(lifetime);
         self.lifetimes.len() - 1
     }
 
-    /// Get the register of <name>, or create it if it doesn't exist.
+    /// Creates a mapping between <name> and a newly created register.
+    pub fn create_reg(&mut self, name: &'a str) -> usize {
+        let reg = self.get_new_reg();
+        self.set_reg(name, reg);
+        reg
+    }
+
+    /// Get the register of <name>.
     pub fn get_reg(&mut self, name: &'a str) -> usize {
         let lifetimes = &mut self.lifetimes;
-        *self
-            .reg_map
+        for map in self.reg_maps[1..].iter().rev() {
+            if let Some(&reg) = map.get(name) {
+                return reg;
+            }
+        }
+        // In lua, if a variable is queried, but isn't in scope, a Nil is returned instead
+        // If none of the maps have a definition for <name> that means we have to define
+        // it ourselves in the map of the module (the first map in <reg_maps>).
+        *self.reg_maps[0]
             .entry(name)
             .and_modify(|reg| {
                 let len = lifetimes.len();
@@ -71,7 +97,7 @@ impl<'a> RegisterMap<'a> {
 
     /// Set the register of <name> to <reg>.
     pub fn set_reg(&mut self, name: &'a str, reg: usize) {
-        self.reg_map.insert(name, reg);
+        self.reg_maps.last_mut().unwrap().insert(name, reg);
     }
 
     /// Get the total number of registers that were needed.
@@ -98,17 +124,34 @@ mod tests {
     }
 
     #[test]
-    fn get_reg_correctly_maps_strings_to_registers() {
+    fn correctly_maps_strings_to_registers() {
         let mut rm = RegisterMap::new();
         // create a new register
         assert_eq!(rm.get_new_reg(), 0);
         // create a mapping
+        assert_eq!(rm.create_reg("foo"), 1);
+        assert_eq!(*rm.reg_maps[0].get("foo").unwrap(), 1);
         assert_eq!(rm.get_reg("foo"), 1);
-        assert_eq!(*rm.reg_map.get("foo").unwrap(), 1);
+        assert_eq!(*rm.reg_maps[0].get("foo").unwrap(), 1);
+        assert_eq!(rm.get_reg("bar"), 2);
+        assert_eq!(*rm.reg_maps[0].get("bar").unwrap(), 2);
+        // create a new scope in which we define another foo
+        rm.push_scope();
+        assert_eq!(rm.create_reg("foo"), 3);
+        assert_eq!(*rm.reg_maps[1].get("foo").unwrap(), 3);
+        assert_eq!(rm.get_reg("foo"), 3);
+        assert_eq!(*rm.reg_maps[1].get("foo").unwrap(), 3);
+        assert_eq!(rm.get_reg("bar"), 2);
+        assert_eq!(*rm.reg_maps[0].get("bar").unwrap(), 2);
+        assert!(rm.reg_maps[1].get("bar").is_none());
+        rm.pop_scope();
+        // pop the scope and query foo and bar again to check if they have the same values
         assert_eq!(rm.get_reg("foo"), 1);
-        assert_eq!(*rm.reg_map.get("foo").unwrap(), 1);
+        assert_eq!(*rm.reg_maps[0].get("foo").unwrap(), 1);
+        assert_eq!(rm.get_reg("bar"), 2);
+        assert_eq!(*rm.reg_maps[0].get("bar").unwrap(), 2);
         // test total number of registers created
-        assert_eq!(rm.reg_count(), 2);
+        assert_eq!(rm.reg_count(), 4);
     }
 
     #[test]
@@ -117,12 +160,30 @@ mod tests {
         let reg1 = rm.get_new_reg();
         assert_eq!(rm.lifetimes[reg1].0, 0);
         assert_eq!(rm.lifetimes[reg1].1, 1);
-        let reg2 = rm.get_reg("reg");
+        let reg2 = rm.create_reg("reg");
         assert_eq!(rm.lifetimes[reg2].0, 1);
         assert_eq!(rm.lifetimes[reg2].1, 2);
         rm.get_reg("reg");
         assert_eq!(rm.lifetimes[reg2].0, 1);
         assert_eq!(rm.lifetimes[reg2].1, 3);
-        assert_eq!(rm.reg_count(), 2);
+        rm.push_scope();
+        let reg3 = rm.create_reg("reg3");
+        rm.pop_scope();
+        assert_eq!(rm.lifetimes[reg3].0, 2);
+        assert_eq!(rm.lifetimes[reg3].1, 3);
+        assert_eq!(rm.reg_count(), 3);
+    }
+
+    #[test]
+    fn registers_are_retrieved_in_the_correct_order() {
+        let mut rm = RegisterMap::new();
+        for i in 0..3 {
+            rm.push_scope();
+            rm.create_reg("foo");
+        }
+        for i in 0..3 {
+            assert_eq!(rm.get_reg("foo"), 2 - i);
+            rm.pop_scope();
+        }
     }
 }

--- a/luacompiler/src/lib/irgen/register_map.rs
+++ b/luacompiler/src/lib/irgen/register_map.rs
@@ -3,11 +3,16 @@ use std::{collections::HashMap, vec::Vec};
 /// Represents a tuple which is used to specify the lifetime of a register.
 /// For example if a register is first used by the 4th instruction of the bytecode, and
 /// used last by the 7th instruction, the register's lifetime would be (4, 8).
+#[derive(PartialEq, Eq, Debug)]
 pub struct Lifetime(usize, usize);
 
 impl Lifetime {
     pub fn new(sp: usize) -> Lifetime {
         Lifetime(sp, sp + 1)
+    }
+
+    pub fn with_end_point(sp: usize, ep: usize) -> Lifetime {
+        Lifetime(sp, ep)
     }
 
     /// Get the start point of the register.
@@ -26,9 +31,8 @@ impl Lifetime {
 }
 
 /// Represents a structure that is used to map Lua variables to registers, and to keep
-/// track of their lifetimes.
+/// track of their lifetimes. Each Lua file has its own register map.
 pub struct RegisterMap<'a> {
-    current_instr: usize,
     lifetimes: Vec<Lifetime>,
     reg_map: HashMap<&'a str, usize>,
 }
@@ -36,35 +40,33 @@ pub struct RegisterMap<'a> {
 impl<'a> RegisterMap<'a> {
     pub fn new() -> RegisterMap<'a> {
         RegisterMap {
-            current_instr: 0,
             lifetimes: vec![],
             reg_map: HashMap::new(),
         }
     }
 
-    /// Increments the current instruction by 1. This method is used by the IR generator
-    /// in order to signify that a new instruction has been processed.
-    pub fn step(&mut self) {
-        self.current_instr += 1;
-    }
-
     /// Creates and returns a new register, whose lifetime begins from self.current_instr.
     pub fn get_new_reg(&mut self) -> usize {
-        self.lifetimes.push(Lifetime::new(self.current_instr));
+        let lifetime = Lifetime::new(self.lifetimes.len());
+        self.lifetimes.push(lifetime);
         self.lifetimes.len() - 1
     }
 
     /// Get the register of <name>, or create it if it doesn't exist.
     pub fn get_reg(&mut self, name: &'a str) -> usize {
-        if let Some(&reg) = self.reg_map.get(name) {
-            // the variable is referenced again, that means its lifetime is increased
-            self.lifetimes[reg].set_end_point(self.current_instr + 1);
-            reg
-        } else {
-            let new_reg = self.get_new_reg();
-            self.reg_map.insert(name, new_reg);
-            new_reg
-        }
+        let lifetimes = &mut self.lifetimes;
+        *self
+            .reg_map
+            .entry(name)
+            .and_modify(|reg| {
+                let len = lifetimes.len();
+                lifetimes[*reg].set_end_point(len + 1);
+            })
+            .or_insert_with(|| {
+                let lifetime = Lifetime::new(lifetimes.len());
+                lifetimes.push(lifetime);
+                lifetimes.len() - 1
+            })
     }
 
     /// Set the register of <name> to <reg>.
@@ -77,7 +79,7 @@ impl<'a> RegisterMap<'a> {
         self.lifetimes.len()
     }
 
-    pub fn get_lifetimes(self) -> Vec<Lifetime> {
+    pub(crate) fn get_lifetimes(self) -> Vec<Lifetime> {
         self.lifetimes
     }
 }
@@ -115,11 +117,9 @@ mod tests {
         let reg1 = rm.get_new_reg();
         assert_eq!(rm.lifetimes[reg1].0, 0);
         assert_eq!(rm.lifetimes[reg1].1, 1);
-        rm.step();
         let reg2 = rm.get_reg("reg");
         assert_eq!(rm.lifetimes[reg2].0, 1);
         assert_eq!(rm.lifetimes[reg2].1, 2);
-        rm.step();
         rm.get_reg("reg");
         assert_eq!(rm.lifetimes[reg2].0, 1);
         assert_eq!(rm.lifetimes[reg2].1, 3);

--- a/luacompiler/src/lib/irgen/register_map.rs
+++ b/luacompiler/src/lib/irgen/register_map.rs
@@ -1,43 +1,80 @@
-use std::{cell::RefCell, collections::HashMap};
+use std::{collections::HashMap, vec::Vec};
 
-/// Represents a structure that is used to keep track of the mapping
-/// between Lua variables and register ids.
-pub struct RegisterMap {
-    reg_count: RefCell<u8>,
-    reg_map: RefCell<HashMap<String, u8>>,
+/// Represents a tuple which is used to specify the lifetime of a register.
+/// For example if a register is first used by the 4th instruction of the bytecode, and
+/// used last by the 7th instruction, the register's lifetime would be (4, 8).
+pub struct Lifetime(usize, usize);
+
+impl Lifetime {
+    pub fn new(sp: usize) -> Lifetime {
+        Lifetime(sp, sp + 1)
+    }
+
+    /// Get the start point of the register.
+    pub fn start_point(&self) -> usize {
+        self.0
+    }
+
+    /// Get the end point of the register.
+    pub fn end_point(&self) -> usize {
+        self.1
+    }
+
+    fn set_end_point(&mut self, ep: usize) {
+        self.1 = ep
+    }
 }
 
-impl RegisterMap {
-    pub fn new() -> RegisterMap {
+/// Represents a structure that is used to map Lua variables to registers, and to keep
+/// track of their lifetimes.
+pub struct RegisterMap<'a> {
+    current_instr: usize,
+    lifetimes: Vec<Lifetime>,
+    reg_map: HashMap<&'a str, usize>,
+}
+
+impl<'a> RegisterMap<'a> {
+    pub fn new() -> RegisterMap<'a> {
         RegisterMap {
-            reg_count: RefCell::new(0),
-            reg_map: RefCell::new(HashMap::new()),
+            current_instr: 0,
+            lifetimes: vec![],
+            reg_map: HashMap::new(),
         }
     }
 
-    /// Generates a fresh register and returns it.
-    /// This is used in cases like `x = 1 + 2 + 3` to generate intermmediate
-    /// registers in which, for instance, the result of 2 + 3 is stored.
-    pub fn new_reg(&self) -> u8 {
-        let to_return = *self.reg_count.borrow();
-        *self.reg_count.borrow_mut() += 1;
-        to_return
+    /// Increments the current instruction by 1. This method is used by the IR generator
+    /// in order to signify that a new instruction has been processed.
+    pub fn step(&mut self) {
+        self.current_instr += 1;
     }
 
-    /// Get the register that corresponds to the given identifier.
-    /// If the corresponding register is not found, a new register is created
-    /// and returned.
-    pub fn get_reg(&self, name: &str) -> u8 {
-        *self
-            .reg_map
-            .borrow_mut()
-            .entry(name.to_string())
-            .or_insert_with(|| self.new_reg())
+    /// Creates and returns a new register, whose lifetime begins from self.current_instr.
+    pub fn get_new_reg(&mut self) -> usize {
+        self.lifetimes.push(Lifetime::new(self.current_instr));
+        self.lifetimes.len() - 1
+    }
+
+    /// Get the register of <name>, or create it if it doesn't exist.
+    pub fn get_reg(&mut self, name: &'a str) -> usize {
+        if let Some(&reg) = self.reg_map.get(name) {
+            // the variable is referenced again, that means its lifetime is increased
+            self.lifetimes[reg].set_end_point(self.current_instr + 1);
+            reg
+        } else {
+            let new_reg = self.get_new_reg();
+            self.reg_map.insert(name, new_reg);
+            new_reg
+        }
+    }
+
+    /// Set the register of <name> to <reg>.
+    pub fn set_reg(&mut self, name: &'a str, reg: usize) {
+        self.reg_map.insert(name, reg);
     }
 
     /// Get the total number of registers that were needed.
-    pub fn reg_count(self) -> u8 {
-        *self.reg_count.borrow_mut()
+    pub fn reg_count(self) -> usize {
+        self.lifetimes.len()
     }
 }
 
@@ -47,28 +84,41 @@ mod tests {
 
     #[test]
     fn new_reg_correctly_increments_counter() {
-        let rm = RegisterMap::new();
+        let mut rm = RegisterMap::new();
         for i in 0..10 {
-            assert_eq!(rm.new_reg(), i);
-            assert_eq!(*rm.reg_count.borrow(), i + 1);
+            assert_eq!(rm.get_new_reg(), i);
         }
         assert_eq!(rm.reg_count(), 10);
     }
 
     #[test]
     fn get_reg_correctly_maps_strings_to_registers() {
-        let rm = RegisterMap::new();
+        let mut rm = RegisterMap::new();
         // create a new register
-        assert_eq!(rm.new_reg(), 0);
-        assert_eq!(*rm.reg_count.borrow(), 1);
+        assert_eq!(rm.get_new_reg(), 0);
         // create a mapping
         assert_eq!(rm.get_reg("foo"), 1);
-        assert_eq!(*rm.reg_count.borrow(), 2);
-        assert_eq!(*rm.reg_map.borrow().get("foo").unwrap(), 1);
+        assert_eq!(*rm.reg_map.get("foo").unwrap(), 1);
         assert_eq!(rm.get_reg("foo"), 1);
-        assert_eq!(*rm.reg_map.borrow().get("foo").unwrap(), 1);
-        assert_eq!(*rm.reg_count.borrow(), 2);
+        assert_eq!(*rm.reg_map.get("foo").unwrap(), 1);
         // test total number of registers created
+        assert_eq!(rm.reg_count(), 2);
+    }
+
+    #[test]
+    fn lifetimes_are_correcly_updated() {
+        let mut rm = RegisterMap::new();
+        let reg1 = rm.get_new_reg();
+        assert_eq!(rm.lifetimes[reg1].0, 0);
+        assert_eq!(rm.lifetimes[reg1].1, 1);
+        rm.step();
+        let reg2 = rm.get_reg("reg");
+        assert_eq!(rm.lifetimes[reg2].0, 1);
+        assert_eq!(rm.lifetimes[reg2].1, 2);
+        rm.step();
+        rm.get_reg("reg");
+        assert_eq!(rm.lifetimes[reg2].0, 1);
+        assert_eq!(rm.lifetimes[reg2].1, 3);
         assert_eq!(rm.reg_count(), 2);
     }
 }

--- a/luacompiler/src/lib/mod.rs
+++ b/luacompiler/src/lib/mod.rs
@@ -9,6 +9,7 @@ extern crate serde_derive;
 extern crate bincode;
 
 pub mod bytecode;
+pub mod bytecodegen;
 pub mod errors;
 pub mod irgen;
 

--- a/luacompiler/src/lib/mod.rs
+++ b/luacompiler/src/lib/mod.rs
@@ -47,8 +47,12 @@ impl LuaParseTree {
         {
             let lexerdef = lua5_3_l::lexerdef();
             let mut lexer = lexerdef.lexer(&mut pt.contents);
-            let tree = lua5_3_y::parse(&mut lexer)?;
-            pt.tree = tree;
+            let (tree, errs) = lua5_3_y::parse(&mut lexer);
+            if let Some(tree) = tree {
+                pt.tree = tree;
+            } else {
+                return Err(CliError::from(errs));
+            }
         }
         Ok(pt)
     }
@@ -65,8 +69,12 @@ impl LuaParseTree {
         {
             let lexerdef = lua5_3_l::lexerdef();
             let mut lexer = lexerdef.lexer(&mut pt.contents);
-            let tree = lua5_3_y::parse(&mut lexer)?;
-            pt.tree = tree;
+            let (tree, errs) = lua5_3_y::parse(&mut lexer);
+            if let Some(tree) = tree {
+                pt.tree = tree;
+            } else {
+                return Err(CliError::from(errs));
+            }
         }
         Ok(pt)
     }

--- a/luacompiler/src/main.rs
+++ b/luacompiler/src/main.rs
@@ -3,7 +3,7 @@ extern crate lrpar;
 extern crate luacompiler;
 
 use clap::{App, Arg};
-use luacompiler::{irgen::LuaToBytecode, LuaParseTree};
+use luacompiler::{bytecodegen::compile_to_bytecode, irgen::compile_to_ir, LuaParseTree};
 use std::path::PathBuf;
 
 fn main() {
@@ -22,8 +22,9 @@ fn main() {
     let file = matches.value_of("INPUT").unwrap();
     let parse_tree = LuaParseTree::new(&file);
     match parse_tree {
-        Ok(pt) => {
-            let bc = LuaToBytecode::new(&pt).compile();
+        Ok(ref pt) => {
+            let ir = compile_to_ir(&pt);
+            let bc = compile_to_bytecode(ir);
             // create a luabc file next to the input file
             let mut path = PathBuf::from(file);
             path.set_extension("luabc");

--- a/luacompiler/tests/integration_test.rs
+++ b/luacompiler/tests/integration_test.rs
@@ -2,14 +2,15 @@ extern crate luacompiler;
 
 use luacompiler::{
     bytecode::instructions::{make_instr, Opcode},
-    irgen::LuaToBytecode,
+    bytecodegen::compile_to_bytecode,
+    irgen::compile_to_ir,
     LuaParseTree,
 };
 
 #[test]
 fn ldi_generation() {
     let pt = LuaParseTree::from_str(String::from("x = 1")).unwrap();
-    let bc = LuaToBytecode::new(&pt).compile();
+    let bc = compile_to_bytecode(compile_to_ir(&pt));
     assert_eq!(bc.instrs_len(), 2);
     assert_eq!(bc.reg_count(), 2);
     assert_eq!(bc.get_int(0), 1);
@@ -20,7 +21,7 @@ fn ldi_generation() {
 #[test]
 fn ldf_generation() {
     let pt = LuaParseTree::from_str(String::from("x = 2.0")).unwrap();
-    let bc = LuaToBytecode::new(&pt).compile();
+    let bc = compile_to_bytecode(compile_to_ir(&pt));
     assert_eq!(bc.instrs_len(), 2);
     assert_eq!(bc.reg_count(), 2);
     assert_eq!(bc.get_float(0).to_string(), "2");
@@ -31,7 +32,7 @@ fn ldf_generation() {
 #[test]
 fn lds_generation() {
     let pt = LuaParseTree::from_str(String::from("x = \"1.2\"")).unwrap();
-    let bc = LuaToBytecode::new(&pt).compile();
+    let bc = compile_to_bytecode(compile_to_ir(&pt));
     assert_eq!(bc.instrs_len(), 2);
     assert_eq!(bc.reg_count(), 2);
     assert_eq!(bc.get_string(0), "1.2");
@@ -41,7 +42,7 @@ fn lds_generation() {
 
 fn assert_bytecode(opcode: Opcode, operation: &str) {
     let pt = LuaParseTree::from_str(String::from(format!("x = 1 {} 2", operation))).unwrap();
-    let bc = LuaToBytecode::new(&pt).compile();
+    let bc = compile_to_bytecode(compile_to_ir(&pt));
     assert_eq!(bc.instrs_len(), 4);
     assert_eq!(bc.reg_count(), 4);
     assert_eq!(bc.get_int(0), 1);

--- a/luavm/src/lib/lua_values/mod.rs
+++ b/luavm/src/lib/lua_values/mod.rs
@@ -321,7 +321,7 @@ mod tests {
         let bar_get = main.get_attr("bar").unwrap();
         assert_eq!(bar_get.kind(), LuaValKind::INT);
         assert_eq!(bar_get.to_int().unwrap(), 2);
-        main.set_attr("bar", LuaVal::from(2.0));
+        main.set_attr("bar", LuaVal::from(2.0)).unwrap();
         let bar_get = main.get_attr("bar").unwrap();
         assert_eq!(bar_get.kind(), LuaValKind::FLOAT);
         assert_float_absolute_eq!(bar_get.to_float().unwrap(), 2.0, 0.1);
@@ -553,7 +553,8 @@ mod tests {
         table2
             .get_attr("foo")
             .unwrap()
-            .set_attr("foo", LuaVal::from(2));
+            .set_attr("foo", LuaVal::from(2))
+            .unwrap();
         assert_eq!(
             table3
                 .get_attr("foo")

--- a/luavm/src/main.rs
+++ b/luavm/src/main.rs
@@ -3,7 +3,7 @@ extern crate luacompiler;
 extern crate luavm;
 
 use clap::{App, Arg};
-use luacompiler::{irgen::LuaToBytecode, LuaParseTree};
+use luacompiler::{bytecodegen::compile_to_bytecode, irgen::compile_to_ir, LuaParseTree};
 use luavm::Vm;
 
 fn main() {
@@ -23,7 +23,7 @@ fn main() {
     let parse_tree = LuaParseTree::new(&file);
     match parse_tree {
         Ok(pt) => {
-            let bc = LuaToBytecode::new(&pt).compile();
+            let bc = compile_to_bytecode(compile_to_ir(&pt));
             let mut vm = Vm::new(bc);
             vm.eval();
         }


### PR DESCRIPTION
This branch adds a new intermediate representation on which it is easier to perform optimizations, and to apply a register allocation algorithm. At the moment, the compiler will crash if the user's program uses more than 256 registers. 

The compiler now translates Lua to the SSA IR, then to Lua bytecode. 