### PR TITLE
Luatable indexing

### DIFF
--- a/luavm/Cargo.toml
+++ b/luavm/Cargo.toml
@@ -8,7 +8,7 @@ name = "luavm"
 path = "src/lib/mod.rs"
 
 [dependencies]
-gc = "0.3"
+gc = { git="https://github.com/rbartlensky/rust-gc", branch="ref-eq" }
 gc_derive = "0.3"
 luacompiler = { path="../luacompiler" }
 assert_float_eq = "1.1.3"

--- a/luavm/src/lib/errors.rs
+++ b/luavm/src/lib/errors.rs
@@ -8,4 +8,6 @@ pub enum LuaError {
     IntConversionErr,
     /// Raised when a conversion to float fails.
     FloatConversionErr,
+    /// Raised when a conversion to string fails.
+    StringConversionErr,
 }

--- a/luavm/src/lib/instructions/loads.rs
+++ b/luavm/src/lib/instructions/loads.rs
@@ -22,6 +22,8 @@ pub fn ldf(vm: &mut Vm, instr: u32) -> Result<(), LuaError> {
     Ok(())
 }
 
-pub fn lds(_vm: &mut Vm, _instr: u32) -> Result<(), LuaError> {
-    unreachable!("Strings are not implemented yet.")
+pub fn lds(vm: &mut Vm, instr: u32) -> Result<(), LuaError> {
+    let val = vm.bytecode.get_string(second_arg(instr));
+    vm.registers[first_arg(instr) as usize] = LuaVal::from(val.to_string());
+    Ok(())
 }

--- a/luavm/src/lib/lua_values/lua_obj.rs
+++ b/luavm/src/lib/lua_values/lua_obj.rs
@@ -62,3 +62,25 @@ impl LuaObj for LuaFloat {
         Ok(self.v)
     }
 }
+
+pub struct LuaString {
+    pub v: String,
+}
+
+impl LuaObj for LuaString {
+    fn clone_box(&self) -> Box<LuaObj> {
+        Box::new(LuaString { v: self.v.clone() })
+    }
+
+    fn is_float(&self) -> bool {
+        true
+    }
+
+    fn to_int(&self) -> Result<i64, LuaError> {
+        self.v.parse().map_err(|_| LuaError::IntConversionErr)
+    }
+
+    fn to_float(&self) -> Result<f64, LuaError> {
+        self.v.parse().map_err(|_| LuaError::FloatConversionErr)
+    }
+}

--- a/luavm/src/lib/lua_values/lua_obj.rs
+++ b/luavm/src/lib/lua_values/lua_obj.rs
@@ -6,9 +6,10 @@ pub trait LuaObj {
     fn clone_box(&self) -> Box<LuaObj>;
     /// Checks whther the underlying type is a float or an int.
     fn is_number(&self) -> bool;
-    /// Checks whether the underlying type is converted to a float when processed in
-    /// arithmetic expressions.
-    fn is_float(&self) -> bool;
+    /// Returns true if the underlying type is either a float or a string.
+    /// In Lua, if either of these two types are used in an arithmetic
+    /// expression, then both arguments are converted to floats.
+    fn is_aop_float(&self) -> bool;
     /// Checks whether the underlying type is a string or not.
     fn is_string(&self) -> bool;
     /// Converts the underlying type to an int.
@@ -17,6 +18,10 @@ pub trait LuaObj {
     fn to_float(&self) -> Result<f64, LuaError>;
     /// Converts the underlying type to a string.
     fn to_string(&self) -> Result<String, LuaError>;
+    /// Gets a reference to the underlying string.
+    fn get_string_ref(&self) -> Option<&str> {
+        None
+    }
 }
 
 /// Boxes the given `LuaObj`, and returns the address of the box.
@@ -43,7 +48,7 @@ impl LuaObj for LuaInt {
         true
     }
 
-    fn is_float(&self) -> bool {
+    fn is_aop_float(&self) -> bool {
         false
     }
 
@@ -73,7 +78,7 @@ impl LuaObj for LuaFloat {
         true
     }
 
-    fn is_float(&self) -> bool {
+    fn is_aop_float(&self) -> bool {
         true
     }
 
@@ -107,7 +112,7 @@ impl LuaObj for LuaString {
         false
     }
 
-    fn is_float(&self) -> bool {
+    fn is_aop_float(&self) -> bool {
         true
     }
 
@@ -125,5 +130,9 @@ impl LuaObj for LuaString {
 
     fn to_string(&self) -> Result<String, LuaError> {
         Ok(self.v.clone())
+    }
+
+    fn get_string_ref(&self) -> Option<&str> {
+        Some(&self.v)
     }
 }

--- a/luavm/src/lib/lua_values/lua_obj.rs
+++ b/luavm/src/lib/lua_values/lua_obj.rs
@@ -4,12 +4,19 @@ use errors::LuaError;
 pub trait LuaObj {
     /// Clones the underlying type, and returns a box of it.
     fn clone_box(&self) -> Box<LuaObj>;
-    /// Checks whether the underlyning type is a float or not.
+    /// Checks whther the underlying type is a float or an int.
+    fn is_number(&self) -> bool;
+    /// Checks whether the underlying type is converted to a float when processed in
+    /// arithmetic expressions.
     fn is_float(&self) -> bool;
+    /// Checks whether the underlying type is a string or not.
+    fn is_string(&self) -> bool;
     /// Converts the underlying type to an int.
     fn to_int(&self) -> Result<i64, LuaError>;
     /// Converts the underlying type to a float.
     fn to_float(&self) -> Result<f64, LuaError>;
+    /// Converts the underlying type to a string.
+    fn to_string(&self) -> Result<String, LuaError>;
 }
 
 /// Boxes the given `LuaObj`, and returns the address of the box.
@@ -32,12 +39,24 @@ impl LuaObj for LuaInt {
         Ok(self.v)
     }
 
+    fn is_number(&self) -> bool {
+        true
+    }
+
     fn is_float(&self) -> bool {
+        false
+    }
+
+    fn is_string(&self) -> bool {
         false
     }
 
     fn to_float(&self) -> Result<f64, LuaError> {
         Ok(self.v as f64)
+    }
+
+    fn to_string(&self) -> Result<String, LuaError> {
+        Ok(self.v.to_string())
     }
 }
 
@@ -50,8 +69,16 @@ impl LuaObj for LuaFloat {
         Box::new(LuaFloat { v: self.v })
     }
 
+    fn is_number(&self) -> bool {
+        true
+    }
+
     fn is_float(&self) -> bool {
         true
+    }
+
+    fn is_string(&self) -> bool {
+        false
     }
 
     fn to_int(&self) -> Result<i64, LuaError> {
@@ -60,6 +87,10 @@ impl LuaObj for LuaFloat {
 
     fn to_float(&self) -> Result<f64, LuaError> {
         Ok(self.v)
+    }
+
+    fn to_string(&self) -> Result<String, LuaError> {
+        Ok(self.v.to_string())
     }
 }
 
@@ -72,7 +103,15 @@ impl LuaObj for LuaString {
         Box::new(LuaString { v: self.v.clone() })
     }
 
+    fn is_number(&self) -> bool {
+        false
+    }
+
     fn is_float(&self) -> bool {
+        true
+    }
+
+    fn is_string(&self) -> bool {
         true
     }
 
@@ -82,5 +121,9 @@ impl LuaObj for LuaString {
 
     fn to_float(&self) -> Result<f64, LuaError> {
         self.v.parse().map_err(|_| LuaError::FloatConversionErr)
+    }
+
+    fn to_string(&self) -> Result<String, LuaError> {
+        Ok(self.v.clone())
     }
 }

--- a/luavm/src/lib/lua_values/lua_table.rs
+++ b/luavm/src/lib/lua_values/lua_table.rs
@@ -5,26 +5,22 @@ use LuaVal;
 /// Represents a table in Lua.
 #[derive(Trace, Finalize)]
 pub struct LuaTable {
-    v: GcCell<HashMap<String, LuaVal>>,
+    v: GcCell<HashMap<LuaVal, LuaVal>>,
 }
 
 impl LuaTable {
     /// Creates a table with the given keys, and values.
-    pub fn new(hm: HashMap<String, LuaVal>) -> LuaTable {
+    pub fn new(hm: HashMap<LuaVal, LuaVal>) -> LuaTable {
         LuaTable { v: GcCell::new(hm) }
     }
 
     /// Sets the given attribute to `val`.
-    pub fn set(&self, attr: &str, val: LuaVal) {
-        self.v
-            .borrow_mut()
-            .entry(attr.to_string())
-            .or_insert(LuaVal::new())
-            .set(val);
+    pub fn set_attr(&self, attr: LuaVal, val: LuaVal) {
+        self.v.borrow_mut().insert(attr, val);
     }
 
     /// Gets a reference to given attribute.
-    pub fn get_attr(&self, attr: &str) -> LuaVal {
+    pub fn get_attr(&self, attr: &LuaVal) -> LuaVal {
         match self.v.borrow().get(attr) {
             Some(val) => val.clone(),
             None => LuaVal::new(),


### PR DESCRIPTION
`LuaTable`s can now be indexed by any `LuaVal`. This is necessary because global variables are all kept in an `_ENV` variable which is a global table. For instance, `x = 2` translates to `_ENV["x"] = 2`. This is also why this PR introduces the `LuaString` type.

More information about why I forked the `gc` crate can be found [here](https://github.com/rbartlensky/Lua-interpreter/commit/1d3351b838b63a450ebd8448dc6e33ce7d70d8db).
