### PR TITLE
Global variables are now loaded from _ENV.

### DIFF
--- a/luacompiler/Cargo.toml
+++ b/luacompiler/Cargo.toml
@@ -13,10 +13,9 @@ name = "luacompiler"
 path = "src/lib/mod.rs"
 
 [dependencies]
-cfgrammar = { git="https://github.com/softdevteam/grmtools" }
-lrlex = { git="https://github.com/softdevteam/grmtools" }
-lrpar = { git="https://github.com/softdevteam/grmtools" }
-lrtable = { git="https://github.com/softdevteam/grmtools" }
+cfgrammar = "0.2"
+lrlex = "0.2"
+lrpar = "0.2"
 bincode = "1.0.1"
 serde = "1.0.80"
 serde_derive = "1.0"
@@ -26,5 +25,6 @@ version = "2.32"
 default-features = false
 
 [build-dependencies]
-lrpar = { git="https://github.com/softdevteam/grmtools" }
-lrlex = { git="https://github.com/softdevteam/grmtools" }
+cfgrammar = "0.2"
+lrlex = "0.2"
+lrpar = "0.2"

--- a/luacompiler/build.rs
+++ b/luacompiler/build.rs
@@ -1,16 +1,17 @@
+extern crate cfgrammar;
 extern crate lrlex;
 extern crate lrpar;
 
+use cfgrammar::yacc::{YaccKind, YaccOriginalActionKind};
 use lrlex::LexerBuilder;
-use lrpar::ActionKind;
 use lrpar::CTParserBuilder;
 
 fn main() -> Result<(), Box<std::error::Error>> {
-    let mut ct = CTParserBuilder::<u8>::new_with_storaget()
+    let lex_rule_ids_map = CTParserBuilder::<u8>::new_with_storaget()
         .error_on_conflicts(false)
-        .action_kind(ActionKind::GenericParseTree);
-    let lex_rule_ids_map = ct.process_file_in_src("lua5_3/lua5_3.y")?;
-    LexerBuilder::new()
+        .yacckind(YaccKind::Original(YaccOriginalActionKind::GenericParseTree))
+        .process_file_in_src("lua5_3/lua5_3.y")?;
+    LexerBuilder::<u8>::new()
         .rule_ids_map(lex_rule_ids_map)
         .process_file_in_src("lua5_3/lua5_3.l")?;
     Ok(())

--- a/luacompiler/src/lib/bytecode/instructions.rs
+++ b/luacompiler/src/lib/bytecode/instructions.rs
@@ -46,17 +46,19 @@ impl HLInstr {
 /// refer to at most 256 constants.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Opcode {
-    MOV = 0,  // R(1) = R(2)
-    LDI = 1,  // R(1) = I(1); load integer from the constant table
-    LDF = 2,  // R(1) = F(1); load float from the constant table
-    LDS = 3,  // R(1) = S(1); load string from the constant table
-    ADD = 4,  // R(1) = R(2) + R(3)
-    SUB = 5,  // R(1) = R(2) - R(3)
-    MUL = 6,  // R(1) = R(2) * R(3)
-    DIV = 7,  // R(1) = R(2) / R(3)
-    MOD = 8,  // R(1) = R(2) % R(3)
-    FDIV = 9, // R(1) = R(2) // R(3)
-    EXP = 10, // R(1) = R(2) ^ R(3)
+    MOV = 0,      // R(1) = R(2)
+    LDI = 1,      // R(1) = I(1); load integer from the constant table
+    LDF = 2,      // R(1) = F(1); load float from the constant table
+    LDS = 3,      // R(1) = S(1); load string from the constant table
+    ADD = 4,      // R(1) = R(2) + R(3)
+    SUB = 5,      // R(1) = R(2) - R(3)
+    MUL = 6,      // R(1) = R(2) * R(3)
+    DIV = 7,      // R(1) = R(2) / R(3)
+    MOD = 8,      // R(1) = R(2) % R(3)
+    FDIV = 9,     // R(1) = R(2) // R(3)
+    EXP = 10,     // R(1) = R(2) ^ R(3)
+    GetAttr = 11, // R(1) = R(2)[R(3)]
+    SetAttr = 12, // R(1)[R(2)] = R(3)
 }
 
 #[cfg(test)]

--- a/luacompiler/src/lib/bytecode/mod.rs
+++ b/luacompiler/src/lib/bytecode/mod.rs
@@ -74,6 +74,11 @@ impl LuaBytecode {
         &self.strings[i as usize]
     }
 
+    /// Gets the size of the string constant table.
+    pub fn get_strings_len(&self) -> usize {
+        self.strings.len()
+    }
+
     /// Serialize the bytecode to a file using bincode.
     pub fn serialize_to_file(&self, file: &str) -> io::Result<()> {
         let mut f = File::create(file)?;

--- a/luacompiler/src/lib/mod.rs
+++ b/luacompiler/src/lib/mod.rs
@@ -3,7 +3,6 @@ extern crate cfgrammar;
 extern crate lrlex;
 #[macro_use]
 extern crate lrpar;
-extern crate lrtable;
 #[macro_use]
 extern crate serde_derive;
 extern crate bincode;

--- a/luacompiler/tests/integration_test.rs
+++ b/luacompiler/tests/integration_test.rs
@@ -11,46 +11,74 @@ use luacompiler::{
 fn ldi_generation() {
     let pt = LuaParseTree::from_str(String::from("x = 1")).unwrap();
     let bc = compile_to_bytecode(compile_to_ir(&pt));
-    assert_eq!(bc.instrs_len(), 2);
-    assert_eq!(bc.reg_count(), 2);
+    assert_eq!(bc.reg_count(), 3);
     assert_eq!(bc.get_int(0), 1);
-    assert_eq!(bc.get_instr(0), make_instr(Opcode::LDI, 0, 0, 0));
-    assert_eq!(bc.get_instr(1), make_instr(Opcode::MOV, 1, 0, 0));
+    assert_eq!(bc.get_string(0), "x");
+    let expected_instrs = vec![
+        make_instr(Opcode::LDI, 1, 0, 0),
+        make_instr(Opcode::LDS, 2, 0, 0),
+        make_instr(Opcode::SetAttr, 0, 2, 1),
+    ];
+    assert_eq!(bc.instrs_len(), expected_instrs.len());
+    for i in 0..expected_instrs.len() {
+        assert_eq!(bc.get_instr(i), expected_instrs[i]);
+    }
 }
 
 #[test]
 fn ldf_generation() {
     let pt = LuaParseTree::from_str(String::from("x = 2.0")).unwrap();
     let bc = compile_to_bytecode(compile_to_ir(&pt));
-    assert_eq!(bc.instrs_len(), 2);
-    assert_eq!(bc.reg_count(), 2);
+    assert_eq!(bc.reg_count(), 3);
     assert_eq!(bc.get_float(0).to_string(), "2");
-    assert_eq!(bc.get_instr(0), make_instr(Opcode::LDF, 0, 0, 0));
-    assert_eq!(bc.get_instr(1), make_instr(Opcode::MOV, 1, 0, 0));
+    assert_eq!(bc.get_string(0), "x");
+    let expected_instrs = vec![
+        make_instr(Opcode::LDF, 1, 0, 0),
+        make_instr(Opcode::LDS, 2, 0, 0),
+        make_instr(Opcode::SetAttr, 0, 2, 1),
+    ];
+    assert_eq!(bc.instrs_len(), expected_instrs.len());
+    for i in 0..expected_instrs.len() {
+        assert_eq!(bc.get_instr(i), expected_instrs[i]);
+    }
 }
 
 #[test]
 fn lds_generation() {
     let pt = LuaParseTree::from_str(String::from("x = \"1.2\"")).unwrap();
     let bc = compile_to_bytecode(compile_to_ir(&pt));
-    assert_eq!(bc.instrs_len(), 2);
-    assert_eq!(bc.reg_count(), 2);
+    assert_eq!(bc.reg_count(), 3);
     assert_eq!(bc.get_string(0), "1.2");
-    assert_eq!(bc.get_instr(0), make_instr(Opcode::LDS, 0, 0, 0));
-    assert_eq!(bc.get_instr(1), make_instr(Opcode::MOV, 1, 0, 0));
+    assert_eq!(bc.get_string(1), "x");
+    let expected_instrs = vec![
+        make_instr(Opcode::LDS, 1, 0, 0),
+        make_instr(Opcode::LDS, 2, 1, 0),
+        make_instr(Opcode::SetAttr, 0, 2, 1),
+    ];
+    assert_eq!(bc.instrs_len(), expected_instrs.len());
+    for i in 0..expected_instrs.len() {
+        assert_eq!(bc.get_instr(i), expected_instrs[i]);
+    }
 }
 
 fn assert_bytecode(opcode: Opcode, operation: &str) {
     let pt = LuaParseTree::from_str(String::from(format!("x = 1 {} 2", operation))).unwrap();
     let bc = compile_to_bytecode(compile_to_ir(&pt));
-    assert_eq!(bc.instrs_len(), 4);
-    assert_eq!(bc.reg_count(), 4);
     assert_eq!(bc.get_int(0), 1);
     assert_eq!(bc.get_int(1), 2);
-    assert_eq!(bc.get_instr(0), make_instr(Opcode::LDI, 0, 0, 0));
-    assert_eq!(bc.get_instr(1), make_instr(Opcode::LDI, 1, 1, 0));
-    assert_eq!(bc.get_instr(2), make_instr(opcode, 2, 0, 1));
-    assert_eq!(bc.get_instr(3), make_instr(Opcode::MOV, 3, 2, 0));
+    assert_eq!(bc.get_string(0), "x");
+    let expected_instrs = vec![
+        make_instr(Opcode::LDI, 1, 0, 0),
+        make_instr(Opcode::LDI, 2, 1, 0),
+        make_instr(opcode, 3, 1, 2),
+        make_instr(Opcode::LDS, 4, 0, 0),
+        make_instr(Opcode::SetAttr, 0, 4, 3),
+    ];
+    assert_eq!(bc.instrs_len(), expected_instrs.len());
+    for i in 0..expected_instrs.len() {
+        assert_eq!(bc.get_instr(i), expected_instrs[i]);
+    }
+    assert_eq!(bc.reg_count(), 5);
 }
 
 #[test]

--- a/luavm/src/lib/instructions/loads.rs
+++ b/luavm/src/lib/instructions/loads.rs
@@ -23,7 +23,10 @@ pub fn ldf(vm: &mut Vm, instr: u32) -> Result<(), LuaError> {
 }
 
 pub fn lds(vm: &mut Vm, instr: u32) -> Result<(), LuaError> {
-    let val = vm.bytecode.get_string(second_arg(instr));
-    vm.registers[first_arg(instr) as usize] = LuaVal::from(val.to_string());
+    let arg2 = second_arg(instr);
+    let val = vm.bytecode.get_string(arg2);
+    // we also want to save the index of the string in the constant table in order to
+    // speed up lookups in _ENV
+    vm.registers[first_arg(instr) as usize] = LuaVal::from((val.to_string(), arg2 as usize));
     Ok(())
 }

--- a/luavm/src/lib/instructions/mod.rs
+++ b/luavm/src/lib/instructions/mod.rs
@@ -1,2 +1,3 @@
 pub mod arithmetic_operators;
 pub mod loads;
+pub mod tables;

--- a/luavm/src/lib/instructions/tables.rs
+++ b/luavm/src/lib/instructions/tables.rs
@@ -1,0 +1,93 @@
+use errors::LuaError;
+use luacompiler::bytecode::instructions::{first_arg, second_arg, third_arg};
+use luacompiler::irgen::register_map::ENV_REG;
+use Vm;
+
+/// R(1) = R(2)[R(3)]
+pub fn get_attr(vm: &mut Vm, instr: u32) -> Result<(), LuaError> {
+    let val = {
+        let arg2 = second_arg(instr) as usize;
+        let from = &vm.registers[arg2];
+        let attr = &vm.registers[third_arg(instr) as usize];
+        match attr.get_constant_index() {
+            Some(i) => {
+                if arg2 == ENV_REG {
+                    vm.env_attrs[i].clone()
+                } else {
+                    from.get_attr(attr)?
+                }
+            }
+            _ => from.get_attr(attr)?,
+        }
+    };
+    vm.registers[first_arg(instr) as usize] = val;
+    Ok(())
+}
+
+/// R(1)[R(2)] = R(3)
+pub fn set_attr(vm: &mut Vm, instr: u32) -> Result<(), LuaError> {
+    let attr = vm.registers[second_arg(instr) as usize].clone();
+    let val = vm.registers[third_arg(instr) as usize].clone();
+    let arg1 = first_arg(instr) as usize;
+    match attr.get_constant_index() {
+        Some(i) => {
+            if arg1 == ENV_REG {
+                vm.env_attrs[i] = val
+            } else {
+                vm.registers[arg1].set_attr(attr, val)?
+            }
+        }
+        _ => vm.registers[arg1].set_attr(attr, val)?,
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lua_values::LuaVal;
+    use luacompiler::{
+        bytecode::instructions::{make_instr, Opcode},
+        bytecodegen::compile_to_bytecode,
+        irgen::compile_to_ir,
+        LuaParseTree,
+    };
+
+    fn get_vm_for(p: String) -> Vm {
+        let pt = LuaParseTree::from_str(p).unwrap();
+        let ir = compile_to_ir(&pt);
+        let bc = compile_to_bytecode(ir);
+        Vm::new(bc)
+    }
+
+    #[test]
+    fn get_attr_works() {
+        // this should generate:
+        // LDI     1 0 0
+        // LDS     2 0 0
+        // SetAttr 0 2 1
+        let mut vm = get_vm_for("x = 2".to_string());
+        vm.eval(); // so that the registers are updated based on the supplied program
+        assert!(get_attr(&mut vm, make_instr(Opcode::GetAttr, 1, ENV_REG as u8, 2)).is_ok());
+        assert_eq!(vm.registers[1], LuaVal::from(2));
+    }
+
+    #[test]
+    fn set_attr_works() {
+        // this should generate:
+        // LDI     1 0 0
+        // LDS     2 0 0
+        // SetAttr 0 2 1
+        let mut vm = get_vm_for("x = 2".to_string());
+        vm.eval(); // so that the registers are updated based on the supplied program
+        assert!(set_attr(&mut vm, make_instr(Opcode::SetAttr, ENV_REG as u8, 2, 1)).is_ok());
+        let index_of_x = 0;
+        assert_eq!(
+            vm.registers[ENV_REG]
+                .get_attr(&LuaVal::from((String::from("x"), index_of_x)))
+                .unwrap(),
+            LuaVal::new()
+        );
+        assert_eq!(vm.env_attrs[index_of_x], LuaVal::from(2));
+    }
+}

--- a/luavm/src/lib/lua_values/lua_obj.rs
+++ b/luavm/src/lib/lua_values/lua_obj.rs
@@ -22,6 +22,11 @@ pub trait LuaObj {
     fn get_string_ref(&self) -> Option<&str> {
         None
     }
+    /// If the underlying type is a String, then this method returns the String's index
+    /// in the constant table.
+    fn get_constant_index(&self) -> Option<usize> {
+        None
+    }
 }
 
 /// Boxes the given `LuaObj`, and returns the address of the box.
@@ -101,11 +106,16 @@ impl LuaObj for LuaFloat {
 
 pub struct LuaString {
     pub v: String,
+    /// The index of the string in the constant table.
+    pub const_index: Option<usize>,
 }
 
 impl LuaObj for LuaString {
     fn clone_box(&self) -> Box<LuaObj> {
-        Box::new(LuaString { v: self.v.clone() })
+        Box::new(LuaString {
+            v: self.v.clone(),
+            const_index: self.const_index,
+        })
     }
 
     fn is_number(&self) -> bool {
@@ -134,5 +144,9 @@ impl LuaObj for LuaString {
 
     fn get_string_ref(&self) -> Option<&str> {
         Some(&self.v)
+    }
+
+    fn get_constant_index(&self) -> Option<usize> {
+        self.const_index
     }
 }

--- a/luavm/src/lib/lua_values/lua_table.rs
+++ b/luavm/src/lib/lua_values/lua_table.rs
@@ -19,7 +19,7 @@ impl LuaTable {
         self.v.borrow_mut().insert(attr, val);
     }
 
-    /// Gets a reference to given attribute.
+    /// Gets a reference to the given attribute.
     pub fn get_attr(&self, attr: &LuaVal) -> LuaVal {
         match self.v.borrow().get(attr) {
             Some(val) => val.clone(),

--- a/luavm/src/lib/lua_values/mod.rs
+++ b/luavm/src/lib/lua_values/mod.rs
@@ -1,5 +1,5 @@
 mod lua_obj;
-mod lua_table;
+pub mod lua_table;
 mod tagging;
 
 use self::{lua_obj::*, lua_table::LuaTable, tagging::*};
@@ -54,6 +54,14 @@ impl LuaVal {
         match self.kind() {
             LuaValKind::BOXED => unsafe { (*self.as_boxed()).is_string() },
             _ => false,
+        }
+    }
+
+    /// Gets the index of the underlying string in the constant table.
+    pub fn get_constant_index(&self) -> Option<usize> {
+        match self.kind() {
+            LuaValKind::BOXED => unsafe { (*self.as_boxed()).get_constant_index() },
+            _ => None,
         }
     }
 
@@ -264,7 +272,24 @@ impl From<String> for LuaVal {
     /// Create a float LuaVal.
     fn from(string: String) -> Self {
         LuaVal {
-            val: LuaValKind::BOXED ^ to_boxed(Box::new(LuaString { v: string })),
+            val: LuaValKind::BOXED
+                ^ to_boxed(Box::new(LuaString {
+                    v: string,
+                    const_index: None,
+                })),
+        }
+    }
+}
+
+impl From<(String, usize)> for LuaVal {
+    /// Create a float LuaVal.
+    fn from(string: (String, usize)) -> Self {
+        LuaVal {
+            val: LuaValKind::BOXED
+                ^ to_boxed(Box::new(LuaString {
+                    v: string.0,
+                    const_index: Some(string.1),
+                })),
         }
     }
 }

--- a/luavm/src/lib/mod.rs
+++ b/luavm/src/lib/mod.rs
@@ -12,18 +12,26 @@ mod instructions;
 mod lua_values;
 
 use errors::LuaError;
-use instructions::{arithmetic_operators::*, loads::*};
-use lua_values::LuaVal;
+use instructions::{arithmetic_operators::*, loads::*, tables::*};
+use lua_values::{lua_table::LuaTable, LuaVal};
 use luacompiler::bytecode::{instructions::opcode, LuaBytecode};
+use std::collections::HashMap;
 
 /// The instruction handler for each opcode.
-const OPCODE_HANDLER: &'static [fn(&mut Vm, u32) -> Result<(), LuaError>] =
-    &[mov, ldi, ldf, lds, add, sub, mul, div, modulus, fdiv, exp];
+const OPCODE_HANDLER: &'static [fn(&mut Vm, u32) -> Result<(), LuaError>] = &[
+    mov, ldi, ldf, lds, add, sub, mul, div, modulus, fdiv, exp, get_attr, set_attr,
+];
 
 /// Represents a `LuaBytecode` interpreter.
 pub struct Vm {
     pub bytecode: LuaBytecode,
     pub registers: Vec<LuaVal>,
+    /// All attributes of _ENV that are also part of the string constant table are stored
+    /// in a vector. Let's consider an example: "x" is mapped to index 2 in the constant
+    /// table. This means that _ENV["x"] = <val> will modify env_attrs[2]. If however
+    /// "x" was not in the constant table, then the lookup of the attribute would be
+    /// done via the `get_attr` method of the `LuaTable` struct.
+    pub env_attrs: Vec<LuaVal>,
 }
 
 impl Vm {
@@ -31,12 +39,16 @@ impl Vm {
     pub fn new(bytecode: LuaBytecode) -> Vm {
         let regs = bytecode.reg_count();
         let mut registers: Vec<LuaVal> = Vec::with_capacity(regs as usize);
-        for _ in 0..regs {
+        registers.push(LuaVal::from(LuaTable::new(HashMap::new())));
+        for _ in 1..regs {
             registers.push(LuaVal::new());
         }
+        let mut env_attrs = Vec::new();
+        env_attrs.resize(bytecode.get_strings_len(), LuaVal::new());
         Vm {
             bytecode,
             registers,
+            env_attrs,
         }
     }
 
@@ -49,5 +61,43 @@ impl Vm {
             (OPCODE_HANDLER[opcode(instr) as usize])(self, instr).unwrap();
             pc += 1;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use luacompiler::irgen::register_map::ENV_REG;
+    use luacompiler::{bytecodegen::compile_to_bytecode, irgen::compile_to_ir, LuaParseTree};
+
+    fn get_vm_for(p: String) -> Vm {
+        let pt = LuaParseTree::from_str(p).unwrap();
+        let ir = compile_to_ir(&pt);
+        let bc = compile_to_bytecode(ir);
+        Vm::new(bc)
+    }
+
+    #[test]
+    fn env_set_and_get() {
+        let mut vm = get_vm_for("x = 3\ny = x + 1".to_string());
+        vm.eval();
+        let index_of_x = 0;
+        // vm.registers[0] has a reference to the _ENV variable
+        // this is true because the compiler always loads the environment into register 0
+        assert_eq!(
+            vm.registers[ENV_REG]
+                .get_attr(&LuaVal::from((String::from("x"), index_of_x)))
+                .unwrap(),
+            LuaVal::new()
+        );
+        assert_eq!(vm.env_attrs[index_of_x], LuaVal::from(3));
+        let index_of_y = 1;
+        assert_eq!(
+            vm.registers[ENV_REG]
+                .get_attr(&LuaVal::from((String::from("y"), index_of_y)))
+                .unwrap(),
+            LuaVal::new()
+        );
+        assert_eq!(vm.env_attrs[index_of_y], LuaVal::from(4));
     }
 }


### PR DESCRIPTION
In the Lua specification, the global variables are loaded from a global
table called `_ENV`. Programs can overwrite this variable as well, and
can read and write from/to it.
There are a few changes:
* The compiler:
  * assumes that `_ENV` is always stored in register 0
  * replaces all global variable writing, and reading with `GetAttr`, and
  `SetAttr` instructions
* The vm:
  * always creates a `LuaTable` and stores it in register 0, so that globals
can be easily accessed.
  * can now set and get attributes of `LuaTable`s