### PR TITLE
Extend code to allow compilation of chunks.

### DIFF
--- a/luacompiler/src/lib/bytecode/instructions.rs
+++ b/luacompiler/src/lib/bytecode/instructions.rs
@@ -25,10 +25,36 @@ pub fn make_instr(opcode: Opcode, arg1: u8, arg2: u8, arg3: u8) -> u32 {
     opcode as u32 + ((arg1 as u32) << 8) + ((arg2 as u32) << 16) + ((arg3 as u32) << 24)
 }
 
+pub fn format_instr(instr: u32) -> String {
+    let i = match opcode(instr) {
+        0 => "Mov",
+        1 => "Ldi",
+        2 => "Ldf",
+        3 => "Lds",
+        4 => "Add",
+        5 => "Sub",
+        6 => "Mul",
+        7 => "Div",
+        8 => "Mod",
+        9 => "FDiv",
+        10 => "Exp",
+        11 => "GetAttr",
+        12 => "SetAttr",
+        _ => unreachable!("No such opcode: {}", opcode(instr)),
+    };
+    format!(
+        "{} {} {} {}",
+        i,
+        first_arg(instr),
+        second_arg(instr),
+        third_arg(instr)
+    )
+}
+
 /// Represents a high level instruction whose operands have a size of usize.
 /// This is used by the frontend to create an SSA IR, which later gets translated
 /// into smaller instructions that fit in 32 bits.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct HLInstr(pub Opcode, pub usize, pub usize, pub usize);
 
 impl HLInstr {

--- a/luacompiler/src/lib/bytecode/mod.rs
+++ b/luacompiler/src/lib/bytecode/mod.rs
@@ -1,7 +1,8 @@
 pub mod instructions;
 
+use self::instructions::format_instr;
 use bincode::{deserialize, serialize};
-use irgen::constants_map::ConstantsMap;
+use irgen::{compiled_func::CompiledFunc, constants_map::ConstantsMap};
 use std::{
     fmt,
     fs::File,
@@ -9,28 +10,90 @@ use std::{
     vec::Vec,
 };
 
+/// Represents a function in Lua.
+#[derive(Serialize, Deserialize)]
+pub struct Function {
+    index: usize,
+    reg_count: usize,
+    // Indecies of all the functions that are the children of this function.
+    functions: Vec<usize>,
+    instrs: Vec<u32>,
+}
+
+impl Function {
+    /// Create a function which holds the given instructions.
+    pub fn from_u32_instrs(instrs: Vec<u32>) -> Function {
+        Function {
+            index: 0,
+            functions: vec![],
+            reg_count: 0,
+            instrs,
+        }
+    }
+
+    /// Get the index in the bytecode of this Function.
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Get the id of the i-th child.
+    pub fn get_func_index(&self, i: usize) -> usize {
+        self.functions[i]
+    }
+
+    pub fn instrs_len(&self) -> usize {
+        self.instrs.len()
+    }
+
+    pub fn get_instr(&self, i: usize) -> u32 {
+        self.instrs[i]
+    }
+
+    /// The total number of registers that this function uses.
+    pub fn reg_count(&self) -> usize {
+        self.reg_count
+    }
+}
+
+impl From<CompiledFunc> for Function {
+    fn from(func: CompiledFunc) -> Function {
+        let mut new_function = Function {
+            index: func.index(),
+            reg_count: func.lifetimes().len(),
+            functions: vec![],
+            instrs: vec![],
+        };
+        new_function.instrs = func.instrs().iter().map(|i| i.as_32bit()).collect();
+        new_function.functions = func.extract_functions();
+        new_function
+    }
+}
+
 /// A simpler representation of Lua
 #[derive(Serialize, Deserialize)]
 pub struct LuaBytecode {
-    reg_count: u8,
     ints: Vec<i64>,
     floats: Vec<f64>,
     strings: Vec<String>,
-    block: Vec<u32>,
+    functions: Vec<Function>,
+    main_function: usize,
 }
 
 impl LuaBytecode {
     /// Create a new bytecode structure.
-    /// * `instrs` - the instructions of the bytecode
+    /// * `main_function` - the id of the main function
     /// * `const_map` - a mapping between constants and their index in the constant table
-    /// * `reg_count` - the total number of registers used by the instructions
-    pub fn new(instrs: Vec<u32>, const_map: ConstantsMap, reg_count: u8) -> LuaBytecode {
+    pub fn new(
+        functions: Vec<Function>,
+        main_function: usize,
+        const_map: ConstantsMap,
+    ) -> LuaBytecode {
         LuaBytecode {
-            reg_count,
             ints: const_map.get_ints(),
             floats: const_map.get_floats(),
             strings: const_map.get_strings(),
-            block: instrs,
+            functions,
+            main_function,
         }
     }
 
@@ -42,21 +105,12 @@ impl LuaBytecode {
         deserialize(&bytes[..]).unwrap()
     }
 
-    /// Get the number of instructions that are part of this block.
-    pub fn instrs_len(&self) -> usize {
-        self.block.len()
+    pub fn get_function(&self, i: usize) -> &Function {
+        &self.functions[i]
     }
 
-    /// Get the list of instructions that can be executed in order
-    /// to perform some computation.
-    pub fn get_instr(&self, index: usize) -> u32 {
-        self.block[index]
-    }
-
-    /// Get the number of registers that this bytecode uses in order to encode
-    /// instructions.
-    pub fn reg_count(&self) -> u8 {
-        self.reg_count
+    pub fn get_main_function(&self) -> usize {
+        self.main_function
     }
 
     /// Retrieve the integer at index <i> in the constant table.
@@ -89,11 +143,14 @@ impl LuaBytecode {
 
 impl fmt::Display for LuaBytecode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{{\n")?;
-        for instr in &self.block {
-            write!(f, "  {}\n", instr)?;
+        for function in &self.functions {
+            write!(f, "Function {} {{\n", function.index())?;
+            for instr in &function.instrs {
+                write!(f, "  {}\n", format_instr(*instr))?;
+            }
+            write!(f, "}}\n")?;
         }
-        write!(f, "}}")
+        Ok(())
     }
 }
 
@@ -114,15 +171,16 @@ mod tests {
         for i in vec!["2.0"] {
             const_map.get_float(i.to_string());
         }
-        LuaBytecode::new(instrs, const_map, 14)
+        let function = Function::from_u32_instrs(instrs);
+        LuaBytecode::new(vec![function], 0, const_map)
     }
 
     #[test]
     fn bytecode_works_correctly() {
         let bc = setup();
-        assert_eq!(bc.reg_count(), 14);
-        assert_eq!(bc.instrs_len(), 14);
-        assert_eq!(bc.get_instr(0), 1);
+        let function = bc.get_function(bc.get_main_function());
+        assert_eq!(function.instrs_len(), 14);
+        assert_eq!(function.get_instr(0), 1);
     }
 
     #[test]
@@ -136,10 +194,12 @@ mod tests {
         file.read_to_end(&mut contents).unwrap();
         remove_file(name).unwrap();
         let bc2 = LuaBytecode::new_from_bytes(contents);
-        assert_eq!(bc.reg_count, bc2.reg_count);
+        let function = bc.get_function(bc.get_main_function());
+        let function2 = bc2.get_function(bc2.get_main_function());
+        assert_eq!(function.reg_count, function2.reg_count);
         assert_eq!(bc.ints, bc2.ints);
         assert_eq!(bc.floats.len(), bc2.floats.len());
         assert_eq!(bc.strings, bc2.strings);
-        assert_eq!(bc.block, bc2.block);
+        assert_eq!(function.instrs, function2.instrs);
     }
 }

--- a/luacompiler/src/lib/bytecodegen/mod.rs
+++ b/luacompiler/src/lib/bytecodegen/mod.rs
@@ -1,4 +1,4 @@
-use bytecode::LuaBytecode;
+use bytecode::{Function, LuaBytecode};
 use irgen::lua_ir::LuaIR;
 
 pub fn compile_to_bytecode(ir: LuaIR) -> LuaBytecode {
@@ -16,11 +16,12 @@ impl LuaIRToLuaBc {
     }
 
     fn compile(self) -> LuaBytecode {
-        assert!(self.ir.lifetimes.len() < 256);
+        let functions = self.ir.functions;
+        assert!(functions[self.ir.main_func].lifetimes().len() < 256);
         LuaBytecode::new(
-            self.ir.instrs.iter().map(|i| i.as_32bit()).collect(),
+            functions.into_iter().map(|i| Function::from(i)).collect(),
+            self.ir.main_func,
             self.ir.const_map,
-            self.ir.lifetimes.len() as u8,
         )
     }
 }

--- a/luacompiler/src/lib/irgen/compiled_func.rs
+++ b/luacompiler/src/lib/irgen/compiled_func.rs
@@ -1,0 +1,55 @@
+use bytecode::instructions::HLInstr;
+use irgen::register_map::Lifetime;
+
+/// Represents a compiled function in Lua.
+#[derive(Debug)]
+pub struct CompiledFunc {
+    index: usize,
+    functions: Vec<usize>,
+    lifetimes: Vec<Lifetime>,
+    instrs: Vec<HLInstr>,
+}
+
+impl CompiledFunc {
+    /// Create a new empty function with the given index.
+    pub fn new(index: usize) -> CompiledFunc {
+        CompiledFunc {
+            index,
+            functions: vec![],
+            lifetimes: vec![],
+            instrs: vec![],
+        }
+    }
+
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Push the id of the function that was compiled in the scope of this function.
+    pub fn push_func(&mut self, i: usize) {
+        self.functions.push(i);
+    }
+
+    /// Get the lifetimes of the registers of this function.
+    pub fn lifetimes(&self) -> &Vec<Lifetime> {
+        &self.lifetimes
+    }
+
+    pub fn set_lifetimes(&mut self, lifetimes: Vec<Lifetime>) {
+        self.lifetimes = lifetimes;
+    }
+
+    /// Add an instruction to this function.
+    pub fn push_instr(&mut self, instr: HLInstr) {
+        self.instrs.push(instr);
+    }
+
+    /// Get a reference to all the instructions of this function.
+    pub fn instrs(&self) -> &Vec<HLInstr> {
+        &self.instrs
+    }
+
+    pub(crate) fn extract_functions(self) -> Vec<usize> {
+        self.functions
+    }
+}

--- a/luacompiler/src/lib/irgen/lua_ir.rs
+++ b/luacompiler/src/lib/irgen/lua_ir.rs
@@ -1,24 +1,18 @@
-use bytecode::instructions::HLInstr;
-use irgen::{constants_map::ConstantsMap, register_map::Lifetime};
+use irgen::{compiled_func::CompiledFunc, constants_map::ConstantsMap};
 
 /// Represents an IR in which all instructions are in SSA form.
 pub struct LuaIR {
-    pub instrs: Vec<HLInstr>,
+    pub functions: Vec<CompiledFunc>,
+    pub main_func: usize,
     pub const_map: ConstantsMap,
-    pub lifetimes: Vec<Lifetime>,
 }
 
 impl LuaIR {
-    pub fn new(
-        instrs: Vec<HLInstr>,
-        const_map: ConstantsMap,
-        mut lifetimes: Vec<Lifetime>,
-    ) -> LuaIR {
-        lifetimes.sort_by(|x, y| x.start_point().cmp(&y.start_point()));
+    pub fn new(functions: Vec<CompiledFunc>, main_func: usize, const_map: ConstantsMap) -> LuaIR {
         LuaIR {
-            instrs,
+            functions,
+            main_func,
             const_map,
-            lifetimes,
         }
     }
 }

--- a/luacompiler/src/lib/irgen/register_map.rs
+++ b/luacompiler/src/lib/irgen/register_map.rs
@@ -6,7 +6,7 @@ pub const ENV_REG: usize = 0;
 /// Represents a tuple which is used to specify the lifetime of a register.
 /// For example if a register is first used by the 4th instruction of the bytecode, and
 /// used last by the 7th instruction, the register's lifetime would be (4, 8).
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct Lifetime(usize, usize);
 
 impl Lifetime {

--- a/luacompiler/tests/integration_test.rs
+++ b/luacompiler/tests/integration_test.rs
@@ -11,7 +11,6 @@ use luacompiler::{
 fn ldi_generation() {
     let pt = LuaParseTree::from_str(String::from("x = 1")).unwrap();
     let bc = compile_to_bytecode(compile_to_ir(&pt));
-    assert_eq!(bc.reg_count(), 3);
     assert_eq!(bc.get_int(0), 1);
     assert_eq!(bc.get_string(0), "x");
     let expected_instrs = vec![
@@ -19,9 +18,11 @@ fn ldi_generation() {
         make_instr(Opcode::LDS, 2, 0, 0),
         make_instr(Opcode::SetAttr, 0, 2, 1),
     ];
-    assert_eq!(bc.instrs_len(), expected_instrs.len());
+    let function = bc.get_function(bc.get_main_function());
+    assert_eq!(function.reg_count(), 3);
+    assert_eq!(function.instrs_len(), expected_instrs.len());
     for i in 0..expected_instrs.len() {
-        assert_eq!(bc.get_instr(i), expected_instrs[i]);
+        assert_eq!(function.get_instr(i), expected_instrs[i]);
     }
 }
 
@@ -29,7 +30,6 @@ fn ldi_generation() {
 fn ldf_generation() {
     let pt = LuaParseTree::from_str(String::from("x = 2.0")).unwrap();
     let bc = compile_to_bytecode(compile_to_ir(&pt));
-    assert_eq!(bc.reg_count(), 3);
     assert_eq!(bc.get_float(0).to_string(), "2");
     assert_eq!(bc.get_string(0), "x");
     let expected_instrs = vec![
@@ -37,9 +37,11 @@ fn ldf_generation() {
         make_instr(Opcode::LDS, 2, 0, 0),
         make_instr(Opcode::SetAttr, 0, 2, 1),
     ];
-    assert_eq!(bc.instrs_len(), expected_instrs.len());
+    let function = bc.get_function(bc.get_main_function());
+    assert_eq!(function.reg_count(), 3);
+    assert_eq!(function.instrs_len(), expected_instrs.len());
     for i in 0..expected_instrs.len() {
-        assert_eq!(bc.get_instr(i), expected_instrs[i]);
+        assert_eq!(function.get_instr(i), expected_instrs[i]);
     }
 }
 
@@ -47,7 +49,6 @@ fn ldf_generation() {
 fn lds_generation() {
     let pt = LuaParseTree::from_str(String::from("x = \"1.2\"")).unwrap();
     let bc = compile_to_bytecode(compile_to_ir(&pt));
-    assert_eq!(bc.reg_count(), 3);
     assert_eq!(bc.get_string(0), "1.2");
     assert_eq!(bc.get_string(1), "x");
     let expected_instrs = vec![
@@ -55,9 +56,11 @@ fn lds_generation() {
         make_instr(Opcode::LDS, 2, 1, 0),
         make_instr(Opcode::SetAttr, 0, 2, 1),
     ];
-    assert_eq!(bc.instrs_len(), expected_instrs.len());
+    let function = bc.get_function(bc.get_main_function());
+    assert_eq!(function.reg_count(), 3);
+    assert_eq!(function.instrs_len(), expected_instrs.len());
     for i in 0..expected_instrs.len() {
-        assert_eq!(bc.get_instr(i), expected_instrs[i]);
+        assert_eq!(function.get_instr(i), expected_instrs[i]);
     }
 }
 
@@ -74,11 +77,12 @@ fn assert_bytecode(opcode: Opcode, operation: &str) {
         make_instr(Opcode::LDS, 4, 0, 0),
         make_instr(Opcode::SetAttr, 0, 4, 3),
     ];
-    assert_eq!(bc.instrs_len(), expected_instrs.len());
+    let function = bc.get_function(bc.get_main_function());
+    assert_eq!(function.reg_count(), 5);
+    assert_eq!(function.instrs_len(), expected_instrs.len());
     for i in 0..expected_instrs.len() {
-        assert_eq!(bc.get_instr(i), expected_instrs[i]);
+        assert_eq!(function.get_instr(i), expected_instrs[i]);
     }
-    assert_eq!(bc.reg_count(), 5);
 }
 
 #[test]

--- a/luavm/src/lib/mod.rs
+++ b/luavm/src/lib/mod.rs
@@ -37,7 +37,9 @@ pub struct Vm {
 impl Vm {
     /// Create a new interpreter for the given bytecode.
     pub fn new(bytecode: LuaBytecode) -> Vm {
-        let regs = bytecode.reg_count();
+        let regs = bytecode
+            .get_function(bytecode.get_main_function())
+            .reg_count();
         let mut registers: Vec<LuaVal> = Vec::with_capacity(regs as usize);
         registers.push(LuaVal::from(LuaTable::new(HashMap::new())));
         for _ in 1..regs {
@@ -55,9 +57,15 @@ impl Vm {
     /// Evaluate the program.
     pub fn eval(&mut self) {
         let mut pc = 0;
-        let len = self.bytecode.instrs_len();
+        let len = self
+            .bytecode
+            .get_function(self.bytecode.get_main_function())
+            .instrs_len();
         while pc < len {
-            let instr = self.bytecode.get_instr(pc);
+            let instr = self
+                .bytecode
+                .get_function(self.bytecode.get_main_function())
+                .get_instr(pc);
             (OPCODE_HANDLER[opcode(instr) as usize])(self, instr).unwrap();
             pc += 1;
         }


### PR DESCRIPTION
The compile considers the module to be a function, making it easier to add upvalues.
The compiler produces a `CompiledFunc` for each function that it encounters.
These are translated into `Function`s, which are easier to understand from the VMs point of of view.