### PR TITLE
Implement print

### DIFF
--- a/luacompiler/src/lib/bytecode/mod.rs
+++ b/luacompiler/src/lib/bytecode/mod.rs
@@ -135,6 +135,10 @@ impl LuaBytecode {
         &self.strings[i as usize]
     }
 
+    pub fn strings(&self) -> &Vec<String> {
+        &self.strings
+    }
+
     /// Gets the size of the string constant table.
     pub fn get_strings_len(&self) -> usize {
         self.strings.len()

--- a/luavm/src/lib/lua_values/lua_closure.rs
+++ b/luavm/src/lib/lua_values/lua_closure.rs
@@ -1,40 +1,139 @@
-use gc::GcCell;
+use crate::{stdlib::StdFunction, Vm};
+use gc::{Finalize, Gc, GcCell, Trace};
+use luacompiler::bytecode::Function;
+
+impl Finalize for Box<LuaClosure> {}
+unsafe impl Trace for Box<LuaClosure> {
+    custom_trace!(_this, {});
+}
 
 /// Represents a closure in Lua.
 #[derive(Trace, Finalize)]
-pub struct LuaClosure {
+pub struct UserFunction {
     index: usize,
+    reg_count: usize,
+    param_count: usize,
     args_count: GcCell<usize>,
     args_start: GcCell<usize>,
 }
 
-impl LuaClosure {
-    /// Creates an empty closure.
-    pub fn new(index: usize) -> LuaClosure {
-        LuaClosure {
+impl UserFunction {
+    pub fn new(index: usize, reg_count: usize, param_count: usize) -> UserFunction {
+        UserFunction {
             index,
+            reg_count,
+            param_count,
             args_count: GcCell::new(0),
             args_start: GcCell::new(0),
         }
     }
+}
 
-    pub fn index(&self) -> usize {
+impl LuaClosure for UserFunction {
+    fn index(&self) -> usize {
         self.index
     }
 
-    pub fn args_count(&self) -> usize {
+    fn args_count(&self) -> usize {
         self.args_count.borrow().clone()
     }
 
-    pub fn set_args_count(&self, count: usize) {
+    fn set_args_count(&self, count: usize) {
         *self.args_count.borrow_mut() = count;
     }
 
-    pub fn args_start(&self) -> usize {
+    fn args_start(&self) -> usize {
         self.args_start.borrow().clone()
     }
 
-    pub fn set_args_start(&self, count: usize) {
+    fn set_args_start(&self, count: usize) {
         *self.args_start.borrow_mut() = count;
     }
+
+    fn reg_count(&self) -> usize {
+        self.reg_count
+    }
+
+    fn param_count(&self) -> usize {
+        self.param_count
+    }
+
+    fn call(&self, vm: &mut Vm) {
+        vm.eval();
+    }
+}
+
+#[derive(Trace, Finalize)]
+pub struct BuiltinFunction {
+    #[unsafe_ignore_trace]
+    handler: fn(&mut Vm),
+    param_count: usize,
+    args_count: GcCell<usize>,
+    args_start: GcCell<usize>,
+}
+
+impl LuaClosure for BuiltinFunction {
+    fn index(&self) -> usize {
+        0
+    }
+
+    fn args_count(&self) -> usize {
+        self.args_count.borrow().clone()
+    }
+
+    fn set_args_count(&self, count: usize) {
+        *self.args_count.borrow_mut() = count;
+    }
+
+    fn args_start(&self) -> usize {
+        self.args_start.borrow().clone()
+    }
+
+    fn set_args_start(&self, count: usize) {
+        *self.args_start.borrow_mut() = count;
+    }
+
+    fn reg_count(&self) -> usize {
+        // builtin functions might use the _ENV register, which is register 0, so their
+        // reg_count is 1
+        1
+    }
+
+    fn param_count(&self) -> usize {
+        self.param_count
+    }
+
+    fn call(&self, vm: &mut Vm) {
+        (self.handler)(vm);
+    }
+}
+
+pub fn from_stdfunction(func: &StdFunction) -> Gc<Box<LuaClosure>> {
+    Gc::new(Box::new(BuiltinFunction {
+        handler: func.handler(),
+        param_count: func.param_count(),
+        args_count: GcCell::new(0),
+        args_start: GcCell::new(0),
+    }))
+}
+
+pub fn from_function(func: &Function) -> Gc<Box<LuaClosure>> {
+    Gc::new(Box::new(UserFunction {
+        index: func.index(),
+        reg_count: func.reg_count(),
+        param_count: func.param_count(),
+        args_count: GcCell::new(0),
+        args_start: GcCell::new(0),
+    }))
+}
+
+pub trait LuaClosure: Trace + Finalize {
+    fn index(&self) -> usize;
+    fn args_count(&self) -> usize;
+    fn set_args_count(&self, count: usize);
+    fn args_start(&self) -> usize;
+    fn set_args_start(&self, count: usize);
+    fn reg_count(&self) -> usize;
+    fn param_count(&self) -> usize;
+    fn call(&self, vm: &mut Vm);
 }

--- a/luavm/src/lib/lua_values/tagging.rs
+++ b/luavm/src/lib/lua_values/tagging.rs
@@ -55,6 +55,6 @@ pub fn table_ptr(encoded_ptr: usize) -> *mut Gc<LuaTable> {
 }
 
 /// Untags the given pointer, and returns a mutable pointer to Gc<LuaClosure>.
-pub fn closure_ptr(encoded_ptr: usize) -> *mut Gc<LuaClosure> {
-    (encoded_ptr ^ LuaValKind::CLOSURE as usize) as *mut Gc<LuaClosure>
+pub fn closure_ptr(encoded_ptr: usize) -> *mut Gc<Box<LuaClosure>> {
+    (encoded_ptr ^ LuaValKind::CLOSURE as usize) as *mut Gc<Box<LuaClosure>>
 }

--- a/luavm/src/lib/stdlib.rs
+++ b/luavm/src/lib/stdlib.rs
@@ -1,0 +1,38 @@
+use super::Vm;
+use std::fmt::Write as FmtWrite;
+
+pub const STDLIB_FUNCS: &'static [StdFunction] = &[StdFunction {
+    name: "print",
+    handler: lua_print,
+    param_count: 0,
+}];
+
+pub struct StdFunction {
+    name: &'static str,
+    handler: fn(&mut Vm),
+    param_count: usize,
+}
+
+impl StdFunction {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn handler(&self) -> fn(&mut Vm) {
+        self.handler.clone()
+    }
+
+    pub fn param_count(&self) -> usize {
+        self.param_count
+    }
+}
+
+pub fn lua_print(vm: &mut Vm) {
+    let args_start = vm.closure.args_start();
+    let args_count = vm.closure.args_count();
+    let mut s = String::new();
+    for i in args_start..(args_start + args_count - 1) {
+        write!(s, "{}\t", &vm.stack[i]).unwrap();
+    }
+    println!("{}{}", s, &vm.stack[args_start + args_count - 1]);
+}

--- a/luavm/src/main.rs
+++ b/luavm/src/main.rs
@@ -12,6 +12,11 @@ fn main() {
         .author("Robert Bartlensky")
         .about("Interpret Lua files")
         .arg(
+            Arg::with_name("bytecode")
+                .long("bytecode")
+                .help("Print the bytecode produced by the compiler."),
+        )
+        .arg(
             Arg::with_name("INPUT")
                 .help("File to interpret")
                 .required(true)
@@ -24,6 +29,9 @@ fn main() {
     match parse_tree {
         Ok(pt) => {
             let bc = compile_to_bytecode(compile_to_ir(&pt));
+            if matches.is_present("bytecode") {
+                println!("{}", &bc);
+            }
             let mut vm = Vm::new(bc);
             vm.eval();
         }


### PR DESCRIPTION
This PR adds an implementation of the print function, and extends the VM to allow closures to have a handler. A handler is a function defined in the vm, which is associated to a `LuaClosure`. If a closure is called and has a handler, the vm will call a rust function (which is the handler) instead of calling `vm.eval`.

The integration tests will be improved in my next PR where I will add the `assert` function.