### PR TITLE
Luavm return values

### DIFF
--- a/luacompiler/src/lib/bytecode/instructions.rs
+++ b/luacompiler/src/lib/bytecode/instructions.rs
@@ -21,7 +21,7 @@ pub fn third_arg(instr: u32) -> u8 {
 }
 
 /// Create an instruction with the given opcode and arguments.
-pub fn make_instr(opcode: Opcode, arg1: u8, arg2: u8, arg3: u8) -> u32 {
+pub const fn make_instr(opcode: Opcode, arg1: u8, arg2: u8, arg3: u8) -> u32 {
     opcode as u32 + ((arg1 as u32) << 8) + ((arg2 as u32) << 16) + ((arg3 as u32) << 24)
 }
 

--- a/luacompiler/src/lib/bytecode/instructions.rs
+++ b/luacompiler/src/lib/bytecode/instructions.rs
@@ -47,6 +47,7 @@ pub fn format_instr(instr: u32) -> String {
         17 => "Eq",
         18 => "MovR",
         19 => "Ret",
+        20 => "SetTop",
         _ => unreachable!("No such opcode: {}", opcode(instr)),
     };
     format!(
@@ -106,7 +107,8 @@ pub enum Opcode {
     EQ = 17, // R(1) == R(2)
     // Copy return value RV(2) into R(1); Arg(3) = 1 or 2 => same reasoning as above
     MOVR = 18,
-    RET = 19, // return to the parent frame
+    RET = 19,    // return to the parent frame
+    SetTop = 20, // set R(1)'s `args_start` to the top of the stack
 }
 
 #[cfg(test)]

--- a/luacompiler/src/lib/irgen/mod.rs
+++ b/luacompiler/src/lib/irgen/mod.rs
@@ -663,6 +663,7 @@ impl<'a> LuaToIR<'a> {
             } if ridx == lua5_3_y::R_ARGS => &nodes[1],
             _ => panic!("Missing node <args> from <functioncall>"),
         };
+        self.functions[self.curr_function].push_instr(HLInstr(Opcode::SetTop, func_reg, 0, 0));
         let exprs = self.get_underlying_exprs(params);
         if exprs.len() > 0 {
             // push the arguments to the function
@@ -956,8 +957,10 @@ mod tests {
                 HLInstr(Opcode::LDS, 2, 1, 0),
                 HLInstr(Opcode::SetAttr, 0, 2, 1),
                 HLInstr(Opcode::GetAttr, 3, 0, 2),
+                HLInstr(Opcode::SetTop, 3, 0, 0),
                 HLInstr(Opcode::CALL, 3, 0, 0),
                 HLInstr(Opcode::GetAttr, 4, 0, 2),
+                HLInstr(Opcode::SetTop, 4, 0, 0),
                 HLInstr(Opcode::CALL, 4, 0, 0),
             ],
             vec![
@@ -988,10 +991,12 @@ mod tests {
                 HLInstr(Opcode::LDS, 2, 1, 0),
                 HLInstr(Opcode::SetAttr, 0, 2, 1),
                 HLInstr(Opcode::GetAttr, 3, 0, 2),
+                HLInstr(Opcode::SetTop, 3, 0, 0),
                 HLInstr(Opcode::LDI, 4, 0, 0),
                 HLInstr(Opcode::PUSH, 4, 0, 0),
                 HLInstr(Opcode::CALL, 3, 1, 0),
                 HLInstr(Opcode::GetAttr, 5, 0, 2),
+                HLInstr(Opcode::SetTop, 5, 0, 0),
                 HLInstr(Opcode::LDS, 6, 0, 0),
                 HLInstr(Opcode::GetAttr, 7, 0, 6),
                 HLInstr(Opcode::PUSH, 7, 0, 0),
@@ -1052,7 +1057,8 @@ mod tests {
                 HLInstr(Opcode::LDS, 2, 0, 0),
                 HLInstr(Opcode::SetAttr, 0, 2, 1), // _ENV["f"] = 1
                 HLInstr(Opcode::GetAttr, 3, 0, 2), // load reference to f
-                HLInstr(Opcode::LDI, 4, 0, 0),     // 1
+                HLInstr(Opcode::SetTop, 3, 0, 0),
+                HLInstr(Opcode::LDI, 4, 0, 0), // 1
                 HLInstr(Opcode::PUSH, 4, 0, 0),
                 HLInstr(Opcode::LDI, 5, 1, 0), // 2
                 HLInstr(Opcode::PUSH, 5, 0, 0),
@@ -1068,8 +1074,9 @@ mod tests {
                 // next register is 6, as VarArg will assign to 4 and 5
                 HLInstr(Opcode::LDS, 6, 0, 0),     // "f"
                 HLInstr(Opcode::GetAttr, 7, 0, 6), // load reference to f
-                HLInstr(Opcode::VarArg, 0, 0, 1),  // push all varargs
-                HLInstr(Opcode::CALL, 7, 1, 0),    // f(...)
+                HLInstr(Opcode::SetTop, 7, 0, 0),
+                HLInstr(Opcode::VarArg, 0, 0, 1), // push all varargs
+                HLInstr(Opcode::CALL, 7, 1, 0),   // f(...)
             ],
         ];
         for i in 0..ir.functions.len() {
@@ -1093,7 +1100,8 @@ mod tests {
                 HLInstr(Opcode::LDS, 2, 3, 0),
                 HLInstr(Opcode::SetAttr, 0, 2, 1), // _ENV["f"] = 1
                 HLInstr(Opcode::GetAttr, 3, 0, 2), // load reference to f
-                HLInstr(Opcode::LDI, 4, 0, 0),     // 1
+                HLInstr(Opcode::SetTop, 3, 0, 0),
+                HLInstr(Opcode::LDI, 4, 0, 0), // 1
                 HLInstr(Opcode::PUSH, 4, 0, 0),
                 HLInstr(Opcode::LDI, 5, 1, 0), // 2
                 HLInstr(Opcode::PUSH, 5, 0, 0),

--- a/luavm/src/lib/instructions/functions.rs
+++ b/luavm/src/lib/instructions/functions.rs
@@ -1,5 +1,6 @@
 use errors::LuaError;
 use lua_values::LuaVal;
+use luacompiler::bytecode::instructions::*;
 use luacompiler::bytecode::instructions::{first_arg, second_arg};
 use Vm;
 
@@ -15,42 +16,53 @@ pub fn closure(vm: &mut Vm, instr: u32) -> Result<(), LuaError> {
 }
 
 pub fn push(vm: &mut Vm, instr: u32) -> Result<(), LuaError> {
-    // push all the variable arguments of the current function to the stack
-    if second_arg(instr) == 1 {
-        let args_count = vm.closure.args_count();
-        let args_start = vm.closure.args_start();
-        // make sure to skip the arguments which are the actual parameters
-        for i in (args_start + vm.closure.param_count())..(args_start + args_count) {
-            let val = vm.stack[i].clone();
-            vm.push(val);
-        }
-    } else {
-        let val = vm.registers[first_arg(instr) as usize].clone();
-        vm.push(val);
-    }
+    let val = vm.registers[first_arg(instr) as usize].clone();
+    vm.push(val);
+    let ret_val = vm.closure.ret_vals();
+    vm.closure.set_ret_vals(ret_val + third_arg(instr) as usize);
     Ok(())
 }
 
+pub fn set_top(vm: &mut Vm, instr: u32) -> Result<(), LuaError> {
+    let closure = vm.registers[first_arg(instr) as usize].get_closure()?;
+    closure.set_args_start(vm.top);
+    Ok(())
+}
+
+const MOVR_0_0_1: u32 = make_instr(Opcode::MOVR, 0, 0, 1);
+const MOVR_0_0_2: u32 = make_instr(Opcode::MOVR, 0, 0, 2);
+
 pub fn call(vm: &mut Vm, instr: u32) -> Result<(), LuaError> {
+    // The frame of a function has the following structure:
+    // arg1       <------ closure.args_start()
+    // arg2
+    // ---------- <CALL> happens here, the caller pushes the arguments for the callee
+    //            vm.top is here when <CALL> is processed
+    // saved-reg1
+    // saved-reg2
+    // ---------- callee saves the registers which it is going to clobber
+    // ret-val1
+    // ret-val2
+    // ---------- vm.top is here when the callee is ready to return
+
+    // save the state of the caller
     let old_closure = vm.closure.clone();
+    let old_pc = vm.pc;
     vm.closure = vm.registers[first_arg(instr) as usize].get_closure()?;
-    // push the first `reg_count` registers to the stack, as the function will modify these
-    let reg_count = vm.closure.reg_count();
-    for i in 1..reg_count {
+    let args_start = vm.closure.args_start();
+    let args_count = vm.top - args_start;
+    vm.closure.set_args_count(args_count);
+    // push the first `reg_count` registers to the stack, as the called function
+    // will modify these
+    for i in 1..vm.closure.reg_count() {
         let reg = vm.registers[i].clone();
         vm.push(reg);
     }
-    // the compiler might have pushed some arguments, but the exact number is encoded
-    // in the second operand of the call instruction
-    // we have to make sure that those arguments are copied where the function expects
-    // its parameters to be located at
-    let args_count = second_arg(instr) as usize;
-    let mut index_of_arg = vm.stack.len() - (reg_count - 1) - args_count;
-    vm.closure.set_args_count(args_count);
-    vm.closure.set_args_start(index_of_arg);
-    let param_count = vm.closure.param_count();
+    // prepare to move arguments into registers; the callee expects the parameters in its
+    // first N registers (excluding 0 which is _ENV), where N is the number of parameters
+    let mut index_of_arg = args_start;
     // copy arguments into registers [R(1)..R(param_count)]
-    for i in 0..param_count {
+    for i in 0..vm.closure.param_count() {
         // if the caller didn't push enough arguments, we have to set the remaining
         // parameter registers to nil, so that we don't use some value from the old frame
         vm.registers[i + 1] = if i < args_count {
@@ -60,33 +72,116 @@ pub fn call(vm: &mut Vm, instr: u32) -> Result<(), LuaError> {
         };
         index_of_arg += 1;
     }
+    // jump to the called function
     vm.closure.clone().call(vm);
-    // restore the registers
-    for (reg, i) in ((vm.top - (reg_count - 1))..(vm.top)).enumerate() {
+    // the called function might have pushed some return values; the exact number is
+    // encoded by <ret_vals>
+    let ret_vals = vm.closure.ret_vals();
+    // restore the registers of the caller
+    for (reg, i) in ((args_start + args_count)..(vm.top - ret_vals)).enumerate() {
         std::mem::swap(&mut vm.registers[reg + 1], &mut vm.stack[i]);
     }
-    vm.top -= args_count + (reg_count - 1);
+    // restore the state of the caller
+    vm.closure.set_ret_vals(0);
     vm.closure = old_closure;
+    vm.pc = old_pc;
+    // if we returned values, then the next few instructions might move these into
+    // registers using the MOVR instruction
+    let len = vm.bytecode.get_function(vm.closure.index()).instrs_len();
+    if ret_vals > 0 && vm.pc + 1 < len {
+        let mut instr = vm
+            .bytecode
+            .get_function(vm.closure.index())
+            .get_instr(vm.pc + 1);
+        // special MOVR cases, see luacompiler/bytecode/instructions.rs
+        // 001 is used to push all return values to the stack as arguments to another call
+        // 002 is used to push all return values to the stack as return values
+        if instr == MOVR_0_0_1 || instr == MOVR_0_0_2 {
+            // We are going to destroy this stackframe, so we might just as well copy
+            // our return values to where we expect them to be when we call the next
+            // function
+            for (i, r) in ((vm.top - ret_vals)..vm.top).enumerate() {
+                vm.stack.swap(r, args_start + i);
+            }
+            vm.pc += 1;
+            vm.top = args_start + ret_vals;
+            // if we are returning values, then the closure's ret_vals counter should be
+            // updated as well
+            if third_arg(instr) > 1 {
+                let curr_ret_vals = vm.closure.ret_vals();
+                vm.closure.set_ret_vals(curr_ret_vals + ret_vals);
+            }
+        } else {
+            while opcode(instr) == Opcode::MOVR as u8 {
+                let from = second_arg(instr) as usize;
+                // if we don't have enough return values to unpack, we return nils
+                vm.registers[first_arg(instr) as usize] = if from < ret_vals {
+                    vm.stack[vm.top - (ret_vals - from)].clone()
+                } else {
+                    LuaVal::new()
+                };
+                vm.pc += 1;
+                if vm.pc + 1 < len {
+                    instr = vm
+                        .bytecode
+                        .get_function(vm.closure.index())
+                        .get_instr(vm.pc + 1);
+                } else {
+                    break;
+                }
+            }
+            // "destroy" our stack frame
+            vm.top = args_start;
+        }
+    } else {
+        vm.top = args_start;
+    }
     Ok(())
 }
 
 pub fn vararg(vm: &mut Vm, instr: u32) -> Result<(), LuaError> {
-    let param_count = vm.bytecode.get_function(vm.closure.index()).param_count();
-    // where they start on the stack
-    let args_start = vm.closure.args_start();
-    let mut var_args_start = args_start + param_count;
-    let var_args_end = args_start + vm.closure.args_count();
-    // The first register which receives a cloned value from varargs
-    let start_reg = first_arg(instr) as usize;
-    // second operand tells us how many registers we have to assign
-    for r in start_reg..(start_reg + second_arg(instr) as usize) {
-        // in the case where we don't have enough arguments to unpack generate Nils
-        vm.registers[r] = if var_args_start < var_args_end {
-            vm.stack[var_args_start].clone()
-        } else {
-            LuaVal::new()
-        };
-        var_args_start += 1;
+    if third_arg(instr) > 0 {
+        let args_count = vm.closure.args_count();
+        let args_start = vm.closure.args_start();
+        // make sure to skip the arguments which are the actual parameters
+        for i in (args_start + vm.closure.param_count())..(args_start + args_count) {
+            let val = vm.stack[i].clone();
+            vm.push(val);
+        }
+        if third_arg(instr) > 1 {
+            let ret_val = vm.closure.ret_vals();
+            vm.closure
+                .set_ret_vals(ret_val + args_count - vm.closure.param_count());
+        }
+    } else {
+        let param_count = vm.bytecode.get_function(vm.closure.index()).param_count();
+        // where they start on the stack
+        let args_start = vm.closure.args_start();
+        let mut var_args_start = args_start + param_count;
+        let var_args_end = args_start + vm.closure.args_count();
+        // The first register which receives a cloned value from varargs
+        let start_reg = first_arg(instr) as usize;
+        // second operand tells us how many registers we have to assign
+        for r in start_reg..(start_reg + second_arg(instr) as usize) {
+            // in the case where we don't have enough arguments to unpack generate Nils
+            vm.registers[r] = if var_args_start < var_args_end {
+                vm.stack[var_args_start].clone()
+            } else {
+                LuaVal::new()
+            };
+            var_args_start += 1;
+        }
     }
+    Ok(())
+}
+
+pub fn movr(_vm: &mut Vm, _instr: u32) -> Result<(), LuaError> {
+    panic!("This should be handled by <call>.")
+}
+
+pub fn ret(vm: &mut Vm, _instr: u32) -> Result<(), LuaError> {
+    let index = vm.closure.index();
+    let len = vm.bytecode.get_function(index).instrs_len();
+    vm.pc = len;
     Ok(())
 }

--- a/luavm/src/lib/lua_values/lua_closure.rs
+++ b/luavm/src/lib/lua_values/lua_closure.rs
@@ -15,6 +15,7 @@ pub struct UserFunction {
     param_count: usize,
     args_count: GcCell<usize>,
     args_start: GcCell<usize>,
+    ret_vals: GcCell<usize>,
 }
 
 impl UserFunction {
@@ -25,6 +26,7 @@ impl UserFunction {
             param_count,
             args_count: GcCell::new(0),
             args_start: GcCell::new(0),
+            ret_vals: GcCell::new(0),
         }
     }
 }
@@ -61,6 +63,14 @@ impl LuaClosure for UserFunction {
     fn call(&self, vm: &mut Vm) {
         vm.eval();
     }
+
+    fn ret_vals(&self) -> usize {
+        self.ret_vals.borrow().clone()
+    }
+
+    fn set_ret_vals(&self, vals: usize) {
+        *self.ret_vals.borrow_mut() = vals;
+    }
 }
 
 #[derive(Trace, Finalize)]
@@ -70,6 +80,7 @@ pub struct BuiltinFunction {
     param_count: usize,
     args_count: GcCell<usize>,
     args_start: GcCell<usize>,
+    ret_vals: GcCell<usize>,
 }
 
 impl LuaClosure for BuiltinFunction {
@@ -106,6 +117,14 @@ impl LuaClosure for BuiltinFunction {
     fn call(&self, vm: &mut Vm) {
         (self.handler)(vm);
     }
+
+    fn ret_vals(&self) -> usize {
+        self.ret_vals.borrow().clone()
+    }
+
+    fn set_ret_vals(&self, vals: usize) {
+        *self.ret_vals.borrow_mut() = vals;
+    }
 }
 
 pub fn from_stdfunction(func: &StdFunction) -> Gc<Box<LuaClosure>> {
@@ -114,6 +133,7 @@ pub fn from_stdfunction(func: &StdFunction) -> Gc<Box<LuaClosure>> {
         param_count: func.param_count(),
         args_count: GcCell::new(0),
         args_start: GcCell::new(0),
+        ret_vals: GcCell::new(0),
     }))
 }
 
@@ -124,6 +144,7 @@ pub fn from_function(func: &Function) -> Gc<Box<LuaClosure>> {
         param_count: func.param_count(),
         args_count: GcCell::new(0),
         args_start: GcCell::new(0),
+        ret_vals: GcCell::new(0),
     }))
 }
 
@@ -136,4 +157,6 @@ pub trait LuaClosure: Trace + Finalize {
     fn reg_count(&self) -> usize;
     fn param_count(&self) -> usize;
     fn call(&self, vm: &mut Vm);
+    fn ret_vals(&self) -> usize;
+    fn set_ret_vals(&self, vals: usize);
 }

--- a/luavm/src/lib/mod.rs
+++ b/luavm/src/lib/mod.rs
@@ -17,8 +17,12 @@ use gc::Gc;
 use instructions::{
     arithmetic_operators::*, functions::*, loads::*, relational_operators::*, tables::*,
 };
-use lua_values::{lua_closure::LuaClosure, lua_table::LuaTable, LuaVal};
-use luacompiler::bytecode::{instructions::opcode, LuaBytecode};
+use lua_values::{
+    lua_closure::{LuaClosure, UserFunction},
+    lua_table::LuaTable,
+    LuaVal,
+};
+use luacompiler::bytecode::{instructions::*, LuaBytecode};
 use std::collections::HashMap;
 use stdlib::STDLIB_FUNCS;
 
@@ -28,7 +32,7 @@ const REG_NUM: usize = 256;
 /// The instruction handler for each opcode.
 const OPCODE_HANDLER: &'static [fn(&mut Vm, u32) -> Result<(), LuaError>] = &[
     mov, ldi, ldf, lds, add, sub, mul, div, modulus, fdiv, exp, get_attr, set_attr, closure, call,
-    push, vararg, eq,
+    push, vararg, eq, movr, ret, set_top,
 ];
 
 /// Represents a `LuaBytecode` interpreter.
@@ -44,6 +48,7 @@ pub struct Vm {
     /// done via the `get_attr` method of the `LuaTable` struct.
     pub env_attrs: Vec<LuaVal>,
     pub closure: Gc<Box<LuaClosure>>,
+    pub pc: usize,
 }
 
 impl Vm {
@@ -57,14 +62,20 @@ impl Vm {
         let mut env_attrs = Vec::new();
         env_attrs.resize(bytecode.get_strings_len(), LuaVal::new());
         Vm::init_stdlib(&bytecode, &mut registers[0], &mut env_attrs);
-        let closure = LuaVal::from(bytecode.get_function(bytecode.get_main_function()));
+        let closure = {
+            let main = bytecode.get_function(bytecode.get_main_function());
+            let boxed: Box<LuaClosure> =
+                Box::new(UserFunction::new(main.index(), 1, main.param_count()));
+            Gc::new(boxed)
+        };
         Vm {
             bytecode,
             registers,
             stack: vec![],
             top: 0,
             env_attrs,
-            closure: closure.get_closure().unwrap(),
+            closure,
+            pc: 0,
         }
     }
 
@@ -82,18 +93,19 @@ impl Vm {
 
     /// Evaluate the program.
     pub fn eval(&mut self) {
-        let mut pc = 0;
+        self.pc = 0;
         let len = self
             .bytecode
             .get_function(self.closure.index())
             .instrs_len();
-        while pc < len {
+        while self.pc < len {
             let instr = self
                 .bytecode
                 .get_function(self.closure.index())
-                .get_instr(pc);
+                .get_instr(self.pc);
+            println!("Executing {}", format_instr(instr));
             (OPCODE_HANDLER[opcode(instr) as usize])(self, instr).unwrap();
-            pc += 1;
+            self.pc += 1;
         }
     }
 
@@ -232,5 +244,118 @@ mod tests {
         assert_eq!(vm.env_attrs[index_of_y], LuaVal::from(2));
         assert_eq!(vm.env_attrs[index_of_z], LuaVal::from(3));
         assert_eq!(vm.env_attrs[index_of_w], LuaVal::new());
+    }
+
+    #[test]
+    fn function_call_with_rets() {
+        let mut vm = get_vm_for(
+            "function f(a, b)
+                 return a + 1, b + 1
+             end
+             x, y = f(1, 2)
+             z, w = f(10, 4), 5"
+                .to_string(),
+        );
+        vm.eval();
+        assert_eq!(vm.top, 0);
+        let index_of_x = 1;
+        let index_of_y = 2;
+        let index_of_z = 3;
+        let index_of_w = 4;
+        // env is correctly updated
+        assert_eq!(vm.env_attrs[index_of_x], LuaVal::from(2));
+        assert_eq!(vm.env_attrs[index_of_y], LuaVal::from(3));
+        assert_eq!(vm.env_attrs[index_of_z], LuaVal::from(11));
+        assert_eq!(vm.env_attrs[index_of_w], LuaVal::from(5));
+    }
+
+    #[test]
+    fn function_call_returning_function_result() {
+        let mut vm = get_vm_for(
+            "function g()
+                 return 1, 2, 3
+             end
+             function f(a)
+                 return a + 1, g()
+             end
+             x, y, z, w = f(0)
+             w1, w2 = f(10), 10"
+                .to_string(),
+        );
+        vm.eval();
+        let index_of_x = 2;
+        let index_of_y = 3;
+        let index_of_z = 4;
+        let index_of_w = 5;
+        let index_of_w1 = 6;
+        let index_of_w2 = 7;
+        assert!(vm.top == 0);
+        // env is correctly updated
+        assert_eq!(vm.env_attrs[index_of_x], LuaVal::from(1));
+        assert_eq!(vm.env_attrs[index_of_y], LuaVal::from(1));
+        assert_eq!(vm.env_attrs[index_of_z], LuaVal::from(2));
+        assert_eq!(vm.env_attrs[index_of_w], LuaVal::from(3));
+        assert_eq!(vm.env_attrs[index_of_w1], LuaVal::from(11));
+        assert_eq!(vm.env_attrs[index_of_w2], LuaVal::from(10));
+    }
+
+    #[test]
+    fn function_call_varargs() {
+        let mut vm = get_vm_for(
+            "function g(...)
+                 return 1, ...
+             end
+             function f(...)
+                 return ..., 3
+             end
+             x, y, z, w = g(0, 1, 2)
+             w1, w2 = f(11, 12, 13), 10"
+                .to_string(),
+        );
+        vm.eval();
+        let index_of_x = 2;
+        let index_of_y = 3;
+        let index_of_z = 4;
+        let index_of_w = 5;
+        let index_of_w1 = 6;
+        let index_of_w2 = 7;
+        assert!(vm.top == 0);
+        // env is correctly updated
+        assert_eq!(vm.env_attrs[index_of_x], LuaVal::from(1));
+        assert_eq!(vm.env_attrs[index_of_y], LuaVal::from(0));
+        assert_eq!(vm.env_attrs[index_of_z], LuaVal::from(1));
+        assert_eq!(vm.env_attrs[index_of_w], LuaVal::from(2));
+        assert_eq!(vm.env_attrs[index_of_w1], LuaVal::from(11));
+        assert_eq!(vm.env_attrs[index_of_w2], LuaVal::from(10));
+    }
+
+    #[test]
+    fn function_call_misc() {
+        let mut vm = get_vm_for(
+            "function g(...)
+                 return f(10, ...)
+             end
+             function f(...)
+                 return 20, ...
+             end
+             function h(a, b, c, d)
+                 return d, c, b, a
+             end
+             x, y, z, w, w1 = h(g(2, 3))"
+                .to_string(),
+        );
+        vm.eval();
+        let index_of_x = 3;
+        let index_of_y = 4;
+        let index_of_z = 5;
+        let index_of_w = 6;
+        let index_of_w1 = 7;
+        assert!(vm.top == 0);
+        // env is correctly updated
+        assert_eq!(vm.env_attrs[index_of_x], LuaVal::from(3));
+        assert_eq!(vm.env_attrs[index_of_y], LuaVal::from(2));
+        assert_eq!(vm.env_attrs[index_of_z], LuaVal::from(10));
+        assert_eq!(vm.env_attrs[index_of_w], LuaVal::from(20));
+        assert_eq!(vm.env_attrs[index_of_w1], LuaVal::new());
     }
 }

--- a/luavm/src/lib/mod.rs
+++ b/luavm/src/lib/mod.rs
@@ -36,6 +36,7 @@ pub struct Vm {
     pub bytecode: LuaBytecode,
     pub registers: Vec<LuaVal>,
     pub stack: Vec<LuaVal>,
+    pub top: usize,
     /// All attributes of _ENV that are also part of the string constant table are stored
     /// in a vector. Let's consider an example: "x" is mapped to index 2 in the constant
     /// table. This means that _ENV["x"] = <val> will modify env_attrs[2]. If however
@@ -61,6 +62,7 @@ impl Vm {
             bytecode,
             registers,
             stack: vec![],
+            top: 0,
             env_attrs,
             closure: closure.get_closure().unwrap(),
         }
@@ -93,6 +95,15 @@ impl Vm {
             (OPCODE_HANDLER[opcode(instr) as usize])(self, instr).unwrap();
             pc += 1;
         }
+    }
+
+    pub fn push(&mut self, val: LuaVal) {
+        if self.top < self.stack.len() {
+            self.stack[self.top] = val;
+        } else {
+            self.stack.push(val);
+        }
+        self.top += 1;
     }
 }
 


### PR DESCRIPTION
This PR implements variable return values in the vm. The vm pushes return values to the stack, and moves them into registers when it encounters `movr` instructions.